### PR TITLE
chore(flake/nixpkgs): `ff0dbd94` -> `4cba8b53`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712439257,
-        "narHash": "sha256-aSpiNepFOMk9932HOax0XwNxbA38GOUVOiXfUVPOrck=",
+        "lastModified": 1712608508,
+        "narHash": "sha256-vMZ5603yU0wxgyQeHJryOI+O61yrX2AHwY6LOFyV1gM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ff0dbd94265ac470dda06a657d5fe49de93b4599",
+        "rev": "4cba8b53da471aea2ab2b0c1f30a81e7c451f4b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`c5dc9a07`](https://github.com/NixOS/nixpkgs/commit/c5dc9a0758fee085743e775c84cc912b86c3e6ad) | `` maintainers: add johnrtitor ``                                      |
| [`10e119a3`](https://github.com/NixOS/nixpkgs/commit/10e119a312e30ea42f281e29d1b79e13552d24cf) | `` nodePackages.prisma: 5.6.0 -> 5.12.1 ``                             |
| [`88299805`](https://github.com/NixOS/nixpkgs/commit/88299805924758ab57a999d4a58a6f45f8005f06) | `` home-assistant-custom-components.local_luftdaten: init at 2.3.1 ``  |
| [`8e4e789b`](https://github.com/NixOS/nixpkgs/commit/8e4e789bb589dc3ca0b3389a14965d98ba885013) | `` prisma-engines: 5.6.0 -> 5.12.1 ``                                  |
| [`2f8b02e8`](https://github.com/NixOS/nixpkgs/commit/2f8b02e883d104a3ffe609a8627e4e3d56174c2b) | `` coqPackages.vscoq-language-server: 2.0.3 → 2.1.2 ``                 |
| [`e42705c9`](https://github.com/NixOS/nixpkgs/commit/e42705c98279f4f602face96269034164b6e77f5) | `` licenses: rename `apsl{10,20}` -> `apple-psl{10,20}` ``             |
| [`7d4b8a10`](https://github.com/NixOS/nixpkgs/commit/7d4b8a1097f4fe58a18c862dd3de5d5382cd0a1c) | `` maa-assistant-arknights: correct license metadata ``                |
| [`a21d6bfa`](https://github.com/NixOS/nixpkgs/commit/a21d6bfa690d5fbcad4a7502262e38cd858498fe) | `` cert-viewer: correct license metadata ``                            |
| [`ebbd8725`](https://github.com/NixOS/nixpkgs/commit/ebbd87250fef06ea90f2920636921a15427b881b) | `` python3Packages.dazl: correct license metadata ``                   |
| [`acfc5c44`](https://github.com/NixOS/nixpkgs/commit/acfc5c448ef2d7565d969d499e6ad80c6881ea0c) | `` python311Packages.mplhep: 0.3.44 -> 0.3.46 ``                       |
| [`845b436b`](https://github.com/NixOS/nixpkgs/commit/845b436b151d3ea78ec68725c4c5a14559323920) | `` protoc-go-inject-tag: init at 1.4.0 ``                              |
| [`59d7b102`](https://github.com/NixOS/nixpkgs/commit/59d7b102edd16f70343cc9ea42c9ac721f3cafa5) | `` maintainers: add elrohirgt ``                                       |
| [`036d7eb0`](https://github.com/NixOS/nixpkgs/commit/036d7eb0e709d5d86075c7761bbdcdcc2635635e) | `` viceroy: 0.9.5 -> 0.9.6 ``                                          |
| [`ad19cee0`](https://github.com/NixOS/nixpkgs/commit/ad19cee09cca703b4da9e084fffec2fab8b55f02) | `` nixos/image/repart: assert maximum label length ``                  |
| [`4c397ea6`](https://github.com/NixOS/nixpkgs/commit/4c397ea6de1d93dc90e8ff7757eaf3b47428b851) | `` systemd-lib: include GPTMaxLabelLength constant ``                  |
| [`829ca395`](https://github.com/NixOS/nixpkgs/commit/829ca395c4b1d4a160032bf7dec6dcc5228a77ab) | `` soundtracker: disable sdl-config darwin time out ``                 |
| [`dce97415`](https://github.com/NixOS/nixpkgs/commit/dce974151f4a2dfafbe8f9128a268800423f99be) | `` soundtracker: 1.0.4 -> 1.0.5 ``                                     |
| [`812c1ea9`](https://github.com/NixOS/nixpkgs/commit/812c1ea95d38152a60fc46345cf2bdbe47c52b06) | `` organicmaps: 2024.03.18-5 -> 2024.03.31-8 ``                        |
| [`e487bc2a`](https://github.com/NixOS/nixpkgs/commit/e487bc2ae19b0c4acde44dfd6a7c2adadba0ea8f) | `` python312Packages.radio-beam: Fix build ``                          |
| [`62df8fb2`](https://github.com/NixOS/nixpkgs/commit/62df8fb2c07fd75b544c364f863d1d7b7665ca9f) | `` python311Packages.django-import-export: 3.3.7 -> 3.3.8 ``           |
| [`75d6be6c`](https://github.com/NixOS/nixpkgs/commit/75d6be6c9984e182f67ca52841beebee99e9bd3c) | `` erlang: add wrapGAppsHook ``                                        |
| [`69ff4517`](https://github.com/NixOS/nixpkgs/commit/69ff451762c93fdcc512126cf75a5ea2d247d6a3) | `` python311Packages.dirigera: 1.0.14 -> 1.1.0 ``                      |
| [`215d144f`](https://github.com/NixOS/nixpkgs/commit/215d144f770a25713d82552c9543c738f819a173) | `` nixos/outline: fix s3 storage (#302567) ``                          |
| [`22ed2f58`](https://github.com/NixOS/nixpkgs/commit/22ed2f5890d6162bf50a01a7b9b3598ee0bd718a) | `` paperless-ngx: 2.7.1 -> 2.7.2 ``                                    |
| [`deb119e7`](https://github.com/NixOS/nixpkgs/commit/deb119e7f77627934657db589f986eb9b4b8997e) | `` paperless-ngx: fix frontend build on darwin (#278377) ``            |
| [`0c8faaf6`](https://github.com/NixOS/nixpkgs/commit/0c8faaf6c535fe015b92912763d3162683364293) | `` python312Packages.aplpy: fix build ``                               |
| [`f3d439a2`](https://github.com/NixOS/nixpkgs/commit/f3d439a25791c0b79038aebf3dcd3c0e1e1a35c3) | `` typos-lsp: 0.1.16 -> 0.1.17 ``                                      |
| [`fe0c9257`](https://github.com/NixOS/nixpkgs/commit/fe0c92572faf77e18e42353637c3cb8ab680a9b0) | `` doc/stdenv: document prefixKey more precisely (#302535) ``          |
| [`b993dd65`](https://github.com/NixOS/nixpkgs/commit/b993dd655ae45bea7c2ffcfa65d1e584d141d700) | `` nwg-hello: 0.1.8 -> 0.1.9 ``                                        |
| [`58b0ab9a`](https://github.com/NixOS/nixpkgs/commit/58b0ab9a5c97d1b6905d90c39a8258dcd69a2165) | `` checkov: 3.2.53 -> 3.2.55 ``                                        |
| [`455a8672`](https://github.com/NixOS/nixpkgs/commit/455a8672f6e41db4c71bdcc86d74424145a1d7ad) | `` python311Packages.trafilatura: 1.8.0 -> 1.8.1 ``                    |
| [`d0990954`](https://github.com/NixOS/nixpkgs/commit/d0990954e02afd3380766a8ed967ce191693876b) | `` python311Packages.mkdocstrings: format with nixfmt ``               |
| [`3c6b55a6`](https://github.com/NixOS/nixpkgs/commit/3c6b55a63ed6d362884d4108a4d658170d4bc93c) | `` python312Packages.tencentcloud-sdk-python: 3.0.1123 -> 3.0.1124 ``  |
| [`58815a66`](https://github.com/NixOS/nixpkgs/commit/58815a66c85c3954f67e04d07d5beb6f03b0c349) | `` python311Packages.ipyvuetify: 1.9.2 -> 1.9.3 ``                     |
| [`8654d13a`](https://github.com/NixOS/nixpkgs/commit/8654d13a6e5c4f904064ac35a762cb6e89b28f5d) | `` python311Packages.mkdocstrings: 0.24.2 -> 0.24.3 ``                 |
| [`3174508c`](https://github.com/NixOS/nixpkgs/commit/3174508c52219fcab1434f7cd17635dc90d91518) | `` add powerpc64 arch ``                                               |
| [`75b52b99`](https://github.com/NixOS/nixpkgs/commit/75b52b992bc342b458ac5c0f09f8c0ab4f237a2d) | `` botan3: 3.2.0 -> 3.3.0 ``                                           |
| [`9b71e6a1`](https://github.com/NixOS/nixpkgs/commit/9b71e6a1a758a805b48ca7b9d34100c2a7a44e4d) | `` reuse: 3.0.1 -> 3.0.2 ``                                            |
| [`1c896bd6`](https://github.com/NixOS/nixpkgs/commit/1c896bd6e13d32dafc0cd09d26ff06164002cc89) | `` nixos/manual: fix sshfs keygen output ``                            |
| [`57f72cfb`](https://github.com/NixOS/nixpkgs/commit/57f72cfbc2b9b242d075618351baf5b6296012f7) | `` gamescope: pin to wlroots_0_17 ``                                   |
| [`aa71ddad`](https://github.com/NixOS/nixpkgs/commit/aa71ddadfa6158532d5267dda4d6db01237db5bd) | `` gamescope: move to by-name ``                                       |
| [`7711331a`](https://github.com/NixOS/nixpkgs/commit/7711331add4a6f50da039828b3df5fd73ec73f52) | `` pwndbg: 2022.12.19 -> 2024.02.14 ``                                 |
| [`d06a34e9`](https://github.com/NixOS/nixpkgs/commit/d06a34e95d071d268cdcbde69401e5d65a869fb9) | `` python3Packages.pwndbg: init at 2024.02.14 ``                       |
| [`72fd7cc7`](https://github.com/NixOS/nixpkgs/commit/72fd7cc73739a3f7dcda7554c56ec5604791e245) | `` python3Packages.gdb-pt-dump: init at 0-unstable-2024-04-01 ``       |
| [`83e8acb8`](https://github.com/NixOS/nixpkgs/commit/83e8acb86b30dd2ccf4f77464961dde33fe37c1b) | `` apkg: 0.4.1 -> 0.5.0 ``                                             |
| [`4479cc7c`](https://github.com/NixOS/nixpkgs/commit/4479cc7cff3dfe6b71f5cc4b7f5ee362f0b2cf11) | `` python312.pkgs.capstone_4: mark as broken ``                        |
| [`811ce925`](https://github.com/NixOS/nixpkgs/commit/811ce9252950616d86dbffd6f9b5b5f8e64e6662) | `` ast-grep: 0.20.2 -> 0.20.3 ``                                       |
| [`09a7c4ae`](https://github.com/NixOS/nixpkgs/commit/09a7c4aeb4a57df3dca13e84e05f0df0cb82f708) | `` xorg.xorgserver: 21.1.11 -> 21.1.12 (security) ``                   |
| [`0214a0aa`](https://github.com/NixOS/nixpkgs/commit/0214a0aa71dc59f8c119fe944c6de186dd43c4b4) | `` pocketbase: 0.22.7 -> 0.22.8 ``                                     |
| [`f601f6b8`](https://github.com/NixOS/nixpkgs/commit/f601f6b835ff67b95fd34b02163cf4df3b2f86ce) | `` heroic: 2.14.0 -> 2.14.1 ``                                         |
| [`0fd66d6c`](https://github.com/NixOS/nixpkgs/commit/0fd66d6c59419584a4606f72e8dc4a0c0a15cfac) | `` simdutf: 5.2.0 -> 5.2.3 ``                                          |
| [`02f20eb7`](https://github.com/NixOS/nixpkgs/commit/02f20eb7ec257ed4acc0a40778032cb3d6c531f5) | `` typos: 1.20.3 -> 1.20.4 ``                                          |
| [`18a5476a`](https://github.com/NixOS/nixpkgs/commit/18a5476aa7779b916e588e99fb438c631a464d77) | `` nixos/ollama: add options to override `HOME` and `OLLAMA_MODELS` `` |
| [`b0dab7cc`](https://github.com/NixOS/nixpkgs/commit/b0dab7cc34ef4d8a1b2de36178da801090bcb271) | `` python311Packages.xmlschema: 3.0.2 -> 3.2.1 ``                      |
| [`266c8809`](https://github.com/NixOS/nixpkgs/commit/266c8809684a9244d9fec71b66f7d0c92758056a) | `` spire: 1.9.2 -> 1.9.3 ``                                            |
| [`bb7feffc`](https://github.com/NixOS/nixpkgs/commit/bb7feffcafedf050b3da2bd224fbe438fa11f028) | `` python312Packages.javaobj-py3: 0.4.3 -> 0.4.4 ``                    |
| [`e78e0bc8`](https://github.com/NixOS/nixpkgs/commit/e78e0bc8a112f394f07c1cc4a8a97d11757a1f8b) | `` python312Packages.django-vite: 3.0.3 -> 3.0.4 ``                    |
| [`0041c6bc`](https://github.com/NixOS/nixpkgs/commit/0041c6bc0bd7bc77d27490a5b68a8e115f15dc35) | `` python312Packages.crytic-compile: 0.3.6 -> 0.3.7 ``                 |
| [`38b68216`](https://github.com/NixOS/nixpkgs/commit/38b68216a50fa6b80c93361c6438bb2cd7aa37c3) | `` nixos/zfs: install zfs udev rules on stage1 ``                      |
| [`6e5a0136`](https://github.com/NixOS/nixpkgs/commit/6e5a0136cf4d1088d3f97b3ea560cd2651b64e30) | `` openvi: 7.4.27 -> 7.5.28 ``                                         |
| [`2b6b838f`](https://github.com/NixOS/nixpkgs/commit/2b6b838f0900e744198b7064b2c72dc8d46f14fe) | `` axel: 2.17.13 -> 2.17.14 ``                                         |
| [`77387aa6`](https://github.com/NixOS/nixpkgs/commit/77387aa696220e9a13ca04203671aca451340686) | `` pupdate: 3.9.1 -> 3.10.1 ``                                         |
| [`c3160517`](https://github.com/NixOS/nixpkgs/commit/c3160517fc6381f86776795e95c97b8ef7b5d2e4) | `` megasync: 4.9.0.0 -> 4.9.1.0 (#302394) ``                           |
| [`2fd33908`](https://github.com/NixOS/nixpkgs/commit/2fd339082345103537d2c15d43904f9a0b6bd627) | `` aichat: 0.14.0 -> 0.15.0 ``                                         |
| [`46397933`](https://github.com/NixOS/nixpkgs/commit/46397933b3c59fe4c9ecfbf0beb0db294d48868f) | `` cakelisp: 0.3.0-unstable-2024-03-21 -> 0.3.0-unstable-2024-04-01 `` |
| [`2863680e`](https://github.com/NixOS/nixpkgs/commit/2863680e43ca2dca4badaf2a1a641a0eff708616) | `` btcdeb: 0.3.20-unstable-2024-02-06 -> 0.3.20-unstable-2024-03-26 `` |
| [`d6ce5586`](https://github.com/NixOS/nixpkgs/commit/d6ce558617c63a27eeccea2cd18e1137ebd071ff) | `` openjk: 0-unstable-2024-03-05 -> 0-unstable-2024-03-25 ``           |
| [`e9905a6d`](https://github.com/NixOS/nixpkgs/commit/e9905a6dc0a90d35d6ed61f3920b81507f25ca57) | `` python311Packages.rapidgzip: 0.13.0 -> 0.13.1 ``                    |
| [`67729a80`](https://github.com/NixOS/nixpkgs/commit/67729a808a925d8cb473a31d069510efa497ef78) | `` python312Packages.pyfibaro: format with nixfmt ``                   |
| [`52fc9bf1`](https://github.com/NixOS/nixpkgs/commit/52fc9bf1b58a3aad564562a2a1c9874a3cc30196) | `` python312Packages.pyfibaro:refactor ``                              |
| [`105655d7`](https://github.com/NixOS/nixpkgs/commit/105655d740effe76b336a17ace2fe50ebae12197) | `` python312Packages.pyfibaro: 0.7.6 -> 0.7.7 ``                       |
| [`610e0d43`](https://github.com/NixOS/nixpkgs/commit/610e0d4320e243419f718b7d684fb9f9a7946bc5) | `` python312Packages.axis: 60 -> 61 ``                                 |
| [`1a4dc94d`](https://github.com/NixOS/nixpkgs/commit/1a4dc94d1e30d5c02aeee1b21a962d09c8c582a6) | `` python312Packages.velbus-aio: format with nixfmt ``                 |
| [`cca5a228`](https://github.com/NixOS/nixpkgs/commit/cca5a2286cc6fe96992af8a294fe71f42d581ca0) | `` python312Packages.velbus-aio: 2024.4.0 -> 2024.4.1 ``               |
| [`a80624bf`](https://github.com/NixOS/nixpkgs/commit/a80624bfc192a78d9623a54ad3979c7111d1fc2d) | `` scilla: format with nixfmt ``                                       |
| [`f1b9f1c8`](https://github.com/NixOS/nixpkgs/commit/f1b9f1c85962aaf904b45fb73d05b42bcffe27f9) | `` scilla: add ldflags ``                                              |
| [`decb18c0`](https://github.com/NixOS/nixpkgs/commit/decb18c0606b3ae5f96172c2af05822293156c05) | `` metasploit: 6.4.1 -> 6.4.2 ``                                       |
| [`7b9aa23d`](https://github.com/NixOS/nixpkgs/commit/7b9aa23df550076f506195bb5935491c56c96753) | `` scilla: 1.2.7 -> 1.3.0 ``                                           |
| [`1164a96e`](https://github.com/NixOS/nixpkgs/commit/1164a96e58fa3ed9f7dbb2cab8d62d1c15b951ef) | `` rPackages.ReactomeContentService4R: fix loading test ``             |
| [`559c9ddd`](https://github.com/NixOS/nixpkgs/commit/559c9ddd9bae08c5959562a90d59ced874c65490) | `` python311Packages.linien-common: 1.0.1 -> 1.0.2 ``                  |
| [`48661b40`](https://github.com/NixOS/nixpkgs/commit/48661b40e47d151c2a684505e1334c0b75ef9ad4) | `` openapi-changes: init at v0.0.61 ``                                 |
| [`55ae0a71`](https://github.com/NixOS/nixpkgs/commit/55ae0a712751779e832db7bbc1e095f6b7a6cfab) | `` c-blosc2: 2.13.2 -> 2.14.3 ``                                       |
| [`1a63e7b2`](https://github.com/NixOS/nixpkgs/commit/1a63e7b260419cf3f2202f235a5156cba21be173) | `` tfswitch: 1.0.0 -> 1.0.2 ``                                         |
| [`e9fed4bc`](https://github.com/NixOS/nixpkgs/commit/e9fed4bcad77e0d04a77a42886d51282f96c2163) | `` nixos/soju: add tests ``                                            |
| [`d772ac18`](https://github.com/NixOS/nixpkgs/commit/d772ac182f949c6290b95b7ac6cd24265598d961) | `` nixos/soju: add sojuctl wrapper with config path ``                 |
| [`5207bb72`](https://github.com/NixOS/nixpkgs/commit/5207bb723ab36f402a5705f43d97eb49d342540a) | `` nixos/soju: add adminSocket.enable option ``                        |
| [`4959d7bc`](https://github.com/NixOS/nixpkgs/commit/4959d7bcd8f41d05a29fed8cb86a0456a1cf557f) | `` nixos/soju: add package option ``                                   |
| [`bf435073`](https://github.com/NixOS/nixpkgs/commit/bf4350735d79fa2fa8e21fb2ceac0081a903a889) | `` whitesur-icon-theme: 2023-01-08 -> 2024-04-08 ``                    |
| [`da155d70`](https://github.com/NixOS/nixpkgs/commit/da155d700dcbd8bec8ea24400e4e8a5afa0d3960) | `` uiua: 0.10.0 -> 0.10.1 ``                                           |