### PR TITLE
chore(flake/nixpkgs): `1042fd8b` -> `cfd6b5fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712791164,
-        "narHash": "sha256-3sbWO1mbpWsLepZGbWaMovSO7ndZeFqDSdX0hZ9nVyw=",
+        "lastModified": 1712963716,
+        "narHash": "sha256-WKm9CvgCldeIVvRz87iOMi8CFVB1apJlkUT4GGvA0iM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1042fd8b148a9105f3c0aca3a6177fd1d9360ba5",
+        "rev": "cfd6b5fc90b15709b780a5a1619695a88505a176",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`6a8ed263`](https://github.com/NixOS/nixpkgs/commit/6a8ed263b8f8661fcfd1d9d2056f9b7154c81258) | `` python312Packages.snakemake-interface-executor-plugins: 9.1.0 -> 9.1.1 ``   |
| [`a8fe1602`](https://github.com/NixOS/nixpkgs/commit/a8fe160216fa928972e8d51457e45cf8a7721eb8) | `` python312Packages.python-telegram-bot: 21.0.1 -> 21.1 ``                    |
| [`d76c4a6d`](https://github.com/NixOS/nixpkgs/commit/d76c4a6d8afcfa06c4e2cc8496f839fff40a99d3) | `` python312Packages.schema-salad: adjust inputs ``                            |
| [`5f09b608`](https://github.com/NixOS/nixpkgs/commit/5f09b60800c798efb8d5596685a4cd7efc808dd3) | `` python312Packages.types-dataclasses: init at 0.6.6 ``                       |
| [`468109d4`](https://github.com/NixOS/nixpkgs/commit/468109d4f7ecd89aae505c95f5d5b1709f93d20c) | `` python312Packages.schema-salad: format with nixfmt ``                       |
| [`6986b2a6`](https://github.com/NixOS/nixpkgs/commit/6986b2a65e081ce2d701365a6b243c5886017dd7) | `` python312Packages.schema-salad: refactor ``                                 |
| [`937ace08`](https://github.com/NixOS/nixpkgs/commit/937ace08554550b1ef431c4778435cd11a0816f9) | `` python312Packages.schema-salad: 8.5.20240311110950 -> 8.5.20240410123758 `` |
| [`606cd894`](https://github.com/NixOS/nixpkgs/commit/606cd8949cb67d8b18b1387ef5f83bfc7390f80d) | `` cargo-shear: init at 0.0.24 ``                                              |
| [`1a0255c9`](https://github.com/NixOS/nixpkgs/commit/1a0255c9b6e3b1b65ce0bfc372ebcc011365d481) | `` maintainers: add uncenter ``                                                |
| [`1572ec6b`](https://github.com/NixOS/nixpkgs/commit/1572ec6bb122d5f28e9f3af1c7fd8b24ce3a0dd3) | `` llvmPackages_{12,13,14,15,16,17,18,git}: use common lld ``                  |
| [`1c224142`](https://github.com/NixOS/nixpkgs/commit/1c224142f583f1a53edeb283f6bd08c7b8e226f7) | `` kdePackages.{kompare,libkomparediff2}: mark broken ``                       |
| [`8c60d2f7`](https://github.com/NixOS/nixpkgs/commit/8c60d2f75cdab1a90d9ca323cdcf34630eb85962) | `` gnomeExtensions.impatience: 0.5.0 -> 0.5.1 ``                               |
| [`5ef8f585`](https://github.com/NixOS/nixpkgs/commit/5ef8f585c49aa9c187bd7223228211f2d9fbac5c) | `` gnomeExtensions.argos: unstable-2023-09-26 -> unstable-2024-04-03 ``        |
| [`dfdc8d67`](https://github.com/NixOS/nixpkgs/commit/dfdc8d67517583c903925f73bc7ce8b31098ce8a) | `` gnomeExtensions.argos: set `passthru.updateScript` ``                       |
| [`b8959b55`](https://github.com/NixOS/nixpkgs/commit/b8959b55dc35a68a2823dc9a32736d712556ac54) | `` gnomeExtensions.mullvad-indicator: add patch for GNOME 46 compat ``         |
| [`ac556a6d`](https://github.com/NixOS/nixpkgs/commit/ac556a6d52cb705fa6a96cc0f6412ea6460d53a8) | `` gnomeExtensions.pop-shell: unstable-2023-11-10 -> unstable-2024-04-04 ``    |
| [`3c84c560`](https://github.com/NixOS/nixpkgs/commit/3c84c5602fe2be1e51997f3447b2fdf10988f17e) | `` gnomeExtensions.pop-shell: set `passthru.updateScript` ``                   |
| [`35e7cd1d`](https://github.com/NixOS/nixpkgs/commit/35e7cd1dfc627a0a41c38c613ab8faf01ffdd309) | `` gnomeExtensions.arcmenu: 52 -> 55 ``                                        |
| [`8b3fe3e2`](https://github.com/NixOS/nixpkgs/commit/8b3fe3e2653ca3480668b460ed384fcebbaa5b12) | `` gnomeExtensions: pull in updates for GNOME 46 ``                            |
| [`d7146d94`](https://github.com/NixOS/nixpkgs/commit/d7146d949477ec56608234fd7e6569f7181ac26b) | `` gnomeExtensions: add support for GNOME 46 ``                                |
| [`8b6957fd`](https://github.com/NixOS/nixpkgs/commit/8b6957fd70f44d18d23c64abcfe12de0ce0e388c) | `` gitleaks: add meta.mainProgram ``                                           |
| [`26238b31`](https://github.com/NixOS/nixpkgs/commit/26238b318fc96c781e24e3804b49e6a85446dbac) | `` ockam: 0.120.0 -> 0.121.0 ``                                                |
| [`d202fd07`](https://github.com/NixOS/nixpkgs/commit/d202fd07ed282aca9485ef66fd75a9c1353abf48) | `` kdePackages.kfilemetadata: add new kcodecs dependency ``                    |
| [`0aed6cb2`](https://github.com/NixOS/nixpkgs/commit/0aed6cb2b36cafbe66ba5ae970e45258e4a59db4) | `` kdePackages.qqc2-desktop-style: add new qttools dependency ``               |
| [`e0e3d312`](https://github.com/NixOS/nixpkgs/commit/e0e3d312c92d6d86f6f0336cada8606f8b8562a7) | `` kdePackages.frameworks: 6.0 -> 6.1 ``                                       |
| [`8cff9765`](https://github.com/NixOS/nixpkgs/commit/8cff9765db3a712e29119ccf16196b6e7aee372d) | `` kdePackages: use stable metadata file, update metadata ``                   |
| [`9df9bb38`](https://github.com/NixOS/nixpkgs/commit/9df9bb382b2d5bbe8464c964d670dc380108cf3f) | `` nixos/greetd: enable desktop session data ``                                |
| [`53247367`](https://github.com/NixOS/nixpkgs/commit/5324736749e93ed387bdb9acc5ecd2a83a3837e9) | `` makima: 0.4.3 -> 0.4.4 ``                                                   |
| [`1fb05243`](https://github.com/NixOS/nixpkgs/commit/1fb05243af3f8deba31d81d3193edc807591df0f) | `` dotnet-outdated: 4.6.0 -> 4.6.1 ``                                          |
| [`a30155a1`](https://github.com/NixOS/nixpkgs/commit/a30155a1ca5a8c5e3007cf566f4a1d9ecf86a3e4) | `` iosevka: 29.0.5 -> 29.1.0 ``                                                |
| [`28555cdd`](https://github.com/NixOS/nixpkgs/commit/28555cdd35486369c3e0d20060428d47999fe51e) | `` luaPackages.toml-edit: 0.1.5-1 -> 0.3.6-1 ``                                |
| [`6c11b115`](https://github.com/NixOS/nixpkgs/commit/6c11b11517f40542efe9d36f007d2378ec908e7a) | `` lshw-gui: init ``                                                           |
| [`623ac957`](https://github.com/NixOS/nixpkgs/commit/623ac957cb99a5647c9cf127ed6b5b9edfbba087) | `` feishin: 0.5.1 -> 0.6.1 ``                                                  |
| [`528149bf`](https://github.com/NixOS/nixpkgs/commit/528149bf41a14963e13741ad8d89b4f5cf9c5434) | `` feishin: build from source ``                                               |
| [`3cfa4ce7`](https://github.com/NixOS/nixpkgs/commit/3cfa4ce75b438fbf243ba4364c812c358a9442ad) | `` signalbackup-tools: 20240406 -> 20240412-2 ``                               |
| [`bbcdd4ae`](https://github.com/NixOS/nixpkgs/commit/bbcdd4ae01fb70345e8a9b94f6849873e30da5a2) | `` bruno: 1.12.2 -> 1.12.3 ``                                                  |
| [`1b655579`](https://github.com/NixOS/nixpkgs/commit/1b6555792933d0340bb55376023c204aa7aacf4c) | `` pineapple-pictures: 0.7.3 -> 0.7.4 ``                                       |
| [`3aeec8f0`](https://github.com/NixOS/nixpkgs/commit/3aeec8f017e8297f7c4de182674f50346eb73825) | `` werf: 1.2.305 -> 1.2.307 ``                                                 |
| [`0c09de94`](https://github.com/NixOS/nixpkgs/commit/0c09de94dc29a143fccb2d82213712836848f76e) | `` inshellisense: 0.0.1-rc.4 -> 0.0.1-rc.12 ``                                 |
| [`e147a147`](https://github.com/NixOS/nixpkgs/commit/e147a1472b3db74b0b829dab05d50be34929236a) | `` python312Packages.publicsuffix: format with nixfmt ``                       |
| [`0d76f09f`](https://github.com/NixOS/nixpkgs/commit/0d76f09f1544f5fb0ebb09a76a804031d6496f34) | `` python312Packages.publicsuffix: refactor ``                                 |
| [`f4d58e6a`](https://github.com/NixOS/nixpkgs/commit/f4d58e6a1bd011db4b86a0cacab01786678c4794) | `` typstyle: 0.11.12 -> 0.11.13 ``                                             |
| [`5244ff28`](https://github.com/NixOS/nixpkgs/commit/5244ff28146d6c1f2e14337c49df23f4be5191d2) | `` python312Packages.publicsuffix2: format with nixfmt ``                      |
| [`c069b1b7`](https://github.com/NixOS/nixpkgs/commit/c069b1b7bdd853410a8f236b9d0683d5e673efd7) | `` ocamlPackages.landmarks{,-ppx}: init at 1.4 ``                              |
| [`94d87a33`](https://github.com/NixOS/nixpkgs/commit/94d87a332a7144f06f7df40872f41c7bfe194385) | `` python312Packages.publicsuffix2: refactor ``                                |
| [`69ef9cc6`](https://github.com/NixOS/nixpkgs/commit/69ef9cc676557248466a1195a96aa797f7af6112) | `` luaPackages.dkjson: 2.6-1 -> 2.7-1 ``                                       |
| [`535fbe55`](https://github.com/NixOS/nixpkgs/commit/535fbe5571ecf7784de7d7ec5466e9c207df85ce) | `` grafana-agent: 0.40.3 -> 0.40.4 ``                                          |
| [`28c37910`](https://github.com/NixOS/nixpkgs/commit/28c37910dee567590ab1370ab187aa3dd0c416ad) | `` python312Packages.niaarm: 0.3.8 -> 0.3.9 ``                                 |
| [`196a4fe6`](https://github.com/NixOS/nixpkgs/commit/196a4fe6ac159616a83708b75e4609703a8bd377) | `` grafana-image-renderer: 3.10.1 -> 3.10.2 ``                                 |
| [`dd6d24ac`](https://github.com/NixOS/nixpkgs/commit/dd6d24ac8d12a5cf0349efea3bea15fa1bdd14f3) | `` brave: remove duplicating arguments ``                                      |
| [`e9c656af`](https://github.com/NixOS/nixpkgs/commit/e9c656afe4cf5aff1f37c9e10ae21bbcae497188) | `` llvmPackages_git: update to 19.0.0-unstable-2024-04-07 ``                   |
| [`8c71431f`](https://github.com/NixOS/nixpkgs/commit/8c71431f1414fcddcbf6b41c4d8d76b4f01853fb) | `` llvmPackages_{12,13,14,15,16,17,18,git}: use common openmp ``               |
| [`eb17291c`](https://github.com/NixOS/nixpkgs/commit/eb17291c0de7829be5b00addd5972a85e96abddf) | `` python312Packages.midea-beautiful-air: 0.10.4 -> 0.10.5 ``                  |
| [`1f171451`](https://github.com/NixOS/nixpkgs/commit/1f1714519a641608378badc34d0456cc66866945) | `` tpnote:  1.24.0 -> 1.24.2 ``                                                |
| [`ae70b81b`](https://github.com/NixOS/nixpkgs/commit/ae70b81b72495f1f16d830e9000f72c3db9acd9e) | `` bear: add DieracDelta as maintainer ``                                      |
| [`75e43f38`](https://github.com/NixOS/nixpkgs/commit/75e43f38d5299549c9cb74d369ddc2db574a90ad) | `` php81Extensions.mongodb: 1.18.0 -> 1.18.1 ``                                |
| [`02e7dd1b`](https://github.com/NixOS/nixpkgs/commit/02e7dd1b6a7483fba3b2272c175c5fd73dffb86b) | `` orchard: 0.16.0 -> 0.16.1 ``                                                |
| [`57386bcc`](https://github.com/NixOS/nixpkgs/commit/57386bcc420665636ace1c41565f803d098c0e0c) | `` kmon: 1.6.4 -> 1.6.5 ``                                                     |
| [`90cdf140`](https://github.com/NixOS/nixpkgs/commit/90cdf140e025c35f39ec55b8ed218a0a02437a78) | `` erlang_26: 26.2.3 -> 26.2.4 ``                                              |
| [`9f30349f`](https://github.com/NixOS/nixpkgs/commit/9f30349f00c8b4f861f136b8c675befe7f7dd456) | `` gammaray: fix build with qt 6.7 ``                                          |
| [`fc323b7d`](https://github.com/NixOS/nixpkgs/commit/fc323b7d238232194fda746e52e4af0159f47815) | `` python311Packages.pyside6: 6.6.0 -> 6.7.0 ``                                |
| [`258f2023`](https://github.com/NixOS/nixpkgs/commit/258f2023d54ec4ace9924c9cddfbc21e19d1b611) | `` python311Packages.shiboken6: 6.6.0 -> 6.7.0 ``                              |
| [`30f9a954`](https://github.com/NixOS/nixpkgs/commit/30f9a9540b60bcfd4e27ddadc4903dd7b8635ed3) | `` python311Packages.pyqt6: 6.6.1 -> 6.7.0.dev2404081550 ``                    |
| [`1763b81a`](https://github.com/NixOS/nixpkgs/commit/1763b81ae5bb398326b81ebb5114f0d476192aab) | `` qt6.{callPackage,qtModule}: raise darwinMinVersion from 10.13 to 11.0 ``    |
| [`ddad7ac4`](https://github.com/NixOS/nixpkgs/commit/ddad7ac4e22727db401da63441427a11c9c1bced) | `` qt6.qtwebengine: drop outdated patches ``                                   |
| [`54fe58fa`](https://github.com/NixOS/nixpkgs/commit/54fe58fae236271e0b922274c3bcd24814acb3b9) | `` qt6.qtdeclarative: refresh patches ``                                       |
| [`abf354c5`](https://github.com/NixOS/nixpkgs/commit/abf354c5e5f1c8ec9f725a7db9c2e084be956ac1) | `` qt6.qtbase: refresh patches ``                                              |
| [`2c35581d`](https://github.com/NixOS/nixpkgs/commit/2c35581d1df90df767241f03236b9790b0dfa6ae) | `` qt6: 6.6.3 -> 6.7.0 ``                                                      |
| [`87c6aa9f`](https://github.com/NixOS/nixpkgs/commit/87c6aa9f544d94195440d7948b0a575d39826ad1) | `` python312Packages.riscv-config: format with nixfmt ``                       |
| [`da390f96`](https://github.com/NixOS/nixpkgs/commit/da390f9631685ac730670fe18401f64778284d5a) | `` python312Packages.riscv-config: refactor ``                                 |
| [`19afc01e`](https://github.com/NixOS/nixpkgs/commit/19afc01e857c02a13ded2d88796afe99f0d493f0) | `` cargo-deny: 0.14.20 -> 0.14.21 ``                                           |
| [`15e2b9da`](https://github.com/NixOS/nixpkgs/commit/15e2b9da42d469611fea7bc53ccaec1c31928eec) | `` automatic-timezoned: 2.0.10 -> 2.0.11 ``                                    |
| [`b8f8bafe`](https://github.com/NixOS/nixpkgs/commit/b8f8bafed101d4e5a47cd37e19bb4d35cd4fa66d) | `` aliyun-cli: 3.0.201 -> 3.0.202 ``                                           |
| [`63676066`](https://github.com/NixOS/nixpkgs/commit/636760666295252c4bbba6d4a2cb03b92ca0f862) | `` zed-editor: mark as broken on darwin ``                                     |
| [`8d3a38e8`](https://github.com/NixOS/nixpkgs/commit/8d3a38e8b19bdd6bf2a2274c91697cd315de0403) | `` NixOS Integration tests: Re-enable for macOS ``                             |
| [`afc09f49`](https://github.com/NixOS/nixpkgs/commit/afc09f49b83806c5a51173189c202570f40e5ad5) | `` cope: remove ``                                                             |
| [`d2d64fd2`](https://github.com/NixOS/nixpkgs/commit/d2d64fd29e8664ca2c8b4290803cff3e3b49a41c) | `` pyradio: 0.9.3.1 -> 0.9.3.2 ``                                              |
| [`13251c32`](https://github.com/NixOS/nixpkgs/commit/13251c32947e0cf454f714c8e3766a8ca1efb91f) | `` python312Packages.batinfo: format with nixfmt ``                            |
| [`6268a5fd`](https://github.com/NixOS/nixpkgs/commit/6268a5fdf239e4cca6c91ae649cc2611702f98a4) | `` python312Packages.batinfo: refactor ``                                      |
| [`c9d195fd`](https://github.com/NixOS/nixpkgs/commit/c9d195fd7d9c4e6d121aa3170268a87c1a71dcc7) | `` python312Packages.aioasuswrt: format with nixfmt ``                         |
| [`b93a93de`](https://github.com/NixOS/nixpkgs/commit/b93a93de03a601d4b95cbf06963155e6ef065981) | `` python312Packages.aioasuswrt: refactor ``                                   |
| [`b701934e`](https://github.com/NixOS/nixpkgs/commit/b701934eaaa6adbd6821f68a90ba96cb769e6233) | `` garage: 0.9.4 -> 1.0.0 ``                                                   |
| [`f452a703`](https://github.com/NixOS/nixpkgs/commit/f452a7030b42d32c14281894decd5edf00cd446a) | `` teams-for-linux: 1.4.17 -> 1.4.22 ``                                        |
| [`06d8f3e3`](https://github.com/NixOS/nixpkgs/commit/06d8f3e3b8c8676adffb498b031b21a452a1c375) | `` python312Packages.aioeafm: format with nixfmt ``                            |
| [`4615f4de`](https://github.com/NixOS/nixpkgs/commit/4615f4dea24be56ccec141189ef2e043265940ab) | `` python312Packages.aioeafm: refactor ``                                      |
| [`c6a0404e`](https://github.com/NixOS/nixpkgs/commit/c6a0404e3e1ec5fe3705d5f3cf16562763d6f513) | `` nixos/display-managers: add renamed option missed in #291913 ``             |
| [`11f3e0c1`](https://github.com/NixOS/nixpkgs/commit/11f3e0c15d7e4792985b93ce932f285c5bfe7b4d) | `` mongodb-4_4: drop ``                                                        |
| [`f12904d2`](https://github.com/NixOS/nixpkgs/commit/f12904d21d5032815a951c7bdddc4169676c9eaa) | `` vunnel: 0.21.2 -> 0.22.0 ``                                                 |
| [`58ce6dcd`](https://github.com/NixOS/nixpkgs/commit/58ce6dcd53857c36ac08071663ec91fe2865c613) | `` workout-tracker: 0.11.2 -> 0.12.0 ``                                        |
| [`defc52f4`](https://github.com/NixOS/nixpkgs/commit/defc52f44275959f854eea82faff1f713fd7465e) | `` raycast: 1.71.1 -> 1.71.3 ``                                                |
| [`f3d71408`](https://github.com/NixOS/nixpkgs/commit/f3d714082edf4874d63530a46013ced97c3808bf) | `` qtile: remove kamilchm from maintainers ``                                  |
| [`88328366`](https://github.com/NixOS/nixpkgs/commit/88328366a3b85cc15918f5cf2876262c9408941f) | `` brave: 1.64.116 -> 1.64.122 ``                                              |
| [`6983df85`](https://github.com/NixOS/nixpkgs/commit/6983df85cf2561d590c7a53dd68427670fe15506) | `` bisq-desktop: 1.9.14 -> 1.9.15 ``                                           |
| [`b6433d21`](https://github.com/NixOS/nixpkgs/commit/b6433d21fcd3de8b53943dac4ed9690ebd2e70cd) | `` brave: fix overriding ``                                                    |
| [`7c363e8f`](https://github.com/NixOS/nixpkgs/commit/7c363e8faca3eaf130000ecdd94b7fd2c382d4ed) | `` python312Packages.homeassistant-stubs: 2024.4.1 -> 2024.4.2 ``              |
| [`84372303`](https://github.com/NixOS/nixpkgs/commit/8437230323be3e0e69d5b536322a01fbbf5f3e10) | `` home-assistant: 2024.4.1 -> 2024.4.2 ``                                     |
| [`c057f8f2`](https://github.com/NixOS/nixpkgs/commit/c057f8f2badd68e72142450120da7f6af386d816) | `` python312Packages.junos-eznc: format with nixfmt ``                         |
| [`553c9184`](https://github.com/NixOS/nixpkgs/commit/553c9184da1fa57aa6b46a61797067937ca75c8c) | `` python312Packages.junos-eznc: refactor ``                                   |
| [`84a50dcf`](https://github.com/NixOS/nixpkgs/commit/84a50dcf5260ead5cb65bbf5f66cfd69095155ff) | `` python312Packages.gekko: format with nixfmt ``                              |
| [`a726656b`](https://github.com/NixOS/nixpkgs/commit/a726656b84a4cdd3f8ed986bb92742f013596805) | `` python312Packages.gekko: refactor ``                                        |