### PR TITLE
chore(flake/nixpkgs): `cfd6b5fc` -> `5672bc9d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712963716,
-        "narHash": "sha256-WKm9CvgCldeIVvRz87iOMi8CFVB1apJlkUT4GGvA0iM=",
+        "lastModified": 1713248628,
+        "narHash": "sha256-NLznXB5AOnniUtZsyy/aPWOk8ussTuePp2acb9U+ISA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cfd6b5fc90b15709b780a5a1619695a88505a176",
+        "rev": "5672bc9dbf9d88246ddab5ac454e82318d094bb8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`060e03e1`](https://github.com/NixOS/nixpkgs/commit/060e03e117e2ba5aeeb7dcdeffcd47ce23630fd8) | `` kafka-cmak: init at 3.0.0.6 ``                                                     |
| [`aae75c75`](https://github.com/NixOS/nixpkgs/commit/aae75c75b7e4edb024a9fffe7a8aaa8c81131fcc) | `` topicctl: 1.16.0 -> 1.16.1 ``                                                      |
| [`14a57dac`](https://github.com/NixOS/nixpkgs/commit/14a57daca95626335cf7447455f48c1c3c8f40f8) | `` python312Packages.blinkpy: 0.22.6 -> 0.22.7 ``                                     |
| [`2cb38a43`](https://github.com/NixOS/nixpkgs/commit/2cb38a43ff2b1eb5550c9839f4bce964856c9950) | `` ocamlPackages.otoml: 1.0.4 -> 1.0.5 ``                                             |
| [`1063186a`](https://github.com/NixOS/nixpkgs/commit/1063186a6696193d7766e29780d64b46bdf59df7) | `` cwltool: 3.1.20240112164112 -> 3.1.20240404144621 ``                               |
| [`c5efa39b`](https://github.com/NixOS/nixpkgs/commit/c5efa39b46dfbca6a42a1a70925fa35b3c009082) | `` devbox: 0.10.4 -> 0.10.5 ``                                                        |
| [`cd7b2fd6`](https://github.com/NixOS/nixpkgs/commit/cd7b2fd691a1a5a6f46a80d818470c9cef10ed17) | `` csview: 1.2.4 -> 1.3.0 ``                                                          |
| [`7bf9024e`](https://github.com/NixOS/nixpkgs/commit/7bf9024e5868e915537f8547a1a09f9f865e8108) | `` ryujinx: 1.1.1248 -> 1.1.1281 ``                                                   |
| [`a3f79fe0`](https://github.com/NixOS/nixpkgs/commit/a3f79fe0b1669401d26f8476ff8fc31944b95e1b) | `` vscodium: 1.88.0.24096 -> 1.88.1.24104 ``                                          |
| [`360dbbad`](https://github.com/NixOS/nixpkgs/commit/360dbbad32ba1d317ce35f75d8c2152f1a89506d) | `` namespace-cli: 0.0.355 -> 0.0.356 ``                                               |
| [`e691d542`](https://github.com/NixOS/nixpkgs/commit/e691d542b55bc24bc83dd773bc823e5963efb64f) | `` aegisub: refactor ``                                                               |
| [`f2d00fba`](https://github.com/NixOS/nixpkgs/commit/f2d00fba3a090e16e8c59ef6673731447ec1a007) | `` aegisub: migrate to by-name ``                                                     |
| [`83201599`](https://github.com/NixOS/nixpkgs/commit/83201599beefbf8d7a32c241b94a647fc4360e8b) | `` dotslash: 0.3.0 -> 0.4.1 ``                                                        |
| [`fc8e2a3a`](https://github.com/NixOS/nixpkgs/commit/fc8e2a3a766d2586133ef44eabff406df56d9430) | `` dotslash: add `passthru.updateScript` config ``                                    |
| [`82b51d46`](https://github.com/NixOS/nixpkgs/commit/82b51d4670ba1743c615ed3d043d0f0b5bbec191) | `` hck: add maintainer gepbird ``                                                     |
| [`7b824e55`](https://github.com/NixOS/nixpkgs/commit/7b824e55d2beef1dd708015e6300a7bbc009853c) | `` hck: 0.9.2 -> 0.10.0 ``                                                            |
| [`3350a1f0`](https://github.com/NixOS/nixpkgs/commit/3350a1f03333ec947df3a37bd51e6d8773dea5d4) | `` firecracker: 1.6.0 -> 1.7.0 ``                                                     |
| [`6c252dcc`](https://github.com/NixOS/nixpkgs/commit/6c252dccc5f95b653d9c896ea9fc16aa2770311c) | `` signalbackup-tools: 20240412-2 -> 20240415-2 ``                                    |
| [`a6677d9f`](https://github.com/NixOS/nixpkgs/commit/a6677d9f6ced90de61031ac65e0ba1188c868d6f) | `` filezilla: 3.66.5 -> 3.67.0 ``                                                     |
| [`99ea3221`](https://github.com/NixOS/nixpkgs/commit/99ea32212d231039859bcdc26bb73c785da646ba) | `` libfilezilla: 0.46.0 -> 0.47.0 ``                                                  |
| [`8ebb85b3`](https://github.com/NixOS/nixpkgs/commit/8ebb85b3342a716ff9f8f42c83a7386c4ca14b0c) | `` putty: 0.80 -> 0.81 ``                                                             |
| [`73c509a1`](https://github.com/NixOS/nixpkgs/commit/73c509a1b8f499638727da877ea60673488f0f6d) | `` wireshark: 4.2.3 -> 4.2.4 ``                                                       |
| [`8326783b`](https://github.com/NixOS/nixpkgs/commit/8326783b9f11fc84911cb0ce67db8dfb0dbcac09) | `` tmuxp: 1.45.0 -> 1.46.0 ``                                                         |
| [`784330e2`](https://github.com/NixOS/nixpkgs/commit/784330e27539b55d79959d979df50ff0cb011e26) | `` treewide: nuke remaining mdDoc leftovers ``                                        |
| [`0dd03da1`](https://github.com/NixOS/nixpkgs/commit/0dd03da1acc71c0341596eface18a42be1cdce87) | `` files-cli: 2.12.56 -> 2.13.2 ``                                                    |
| [`aa1063df`](https://github.com/NixOS/nixpkgs/commit/aa1063df89e2ca0b3d53bce6cba08146b506f5f2) | `` gickup: 0.10.28 -> 0.10.29 ``                                                      |
| [`7801483a`](https://github.com/NixOS/nixpkgs/commit/7801483ab9e2587bdeef6cc5d7da7e7e499851e1) | `` fluxcd: convert hashes to SRI ``                                                   |
| [`133a43d6`](https://github.com/NixOS/nixpkgs/commit/133a43d6553bf2bdf1b39c7e2a62d291fd82052b) | `` firefox-esr-115-unwrapped: 115.9.1esr -> 115.10.0esr ``                            |
| [`9edc63e5`](https://github.com/NixOS/nixpkgs/commit/9edc63e50da07b2015d127190f5e868e3c905db3) | `` firefox-bin-unwrapped: 124.0.2 -> 125.0 ``                                         |
| [`e1728ff7`](https://github.com/NixOS/nixpkgs/commit/e1728ff7f53cc75f4ae228faae9088452d7063b3) | `` fluxcd: use SRI hash in update script ``                                           |
| [`789f7bb8`](https://github.com/NixOS/nixpkgs/commit/789f7bb881514e28597fea17a219628b250928ca) | `` firefox-unwrapped: 124.0.2 -> 125.0 ``                                             |
| [`94069e2d`](https://github.com/NixOS/nixpkgs/commit/94069e2d50bee6f7841fd57feb993305b3600fc4) | `` coder: use sri hash in updateScript ``                                             |
| [`b22c3951`](https://github.com/NixOS/nixpkgs/commit/b22c3951f5e579dc1f132e2a922630ba6ecfef25) | `` libreoffice: add coreutils, gnugrep in wrapper ``                                  |
| [`47908a11`](https://github.com/NixOS/nixpkgs/commit/47908a114b3866efce8a9d9533c5c23510f5f7ae) | `` maintainers: add matrix for anthonyroussel ``                                      |
| [`8706b488`](https://github.com/NixOS/nixpkgs/commit/8706b488716e310f02e5ddc94204dc3fa81d511e) | `` python312Packages.snakemake-interface-storage-plugins: 3.1.1 -> 3.2.0 (#304299) `` |
| [`e9489ba9`](https://github.com/NixOS/nixpkgs/commit/e9489ba998eede2b42e31c21e2672f5c29cb3648) | `` ols: 0-unstable-2024-02-09 -> 0-unstable-2024-04-15 ``                             |
| [`7e690b78`](https://github.com/NixOS/nixpkgs/commit/7e690b788b828a98df5f4988e0483b63430db401) | `` reviewdog: 0.17.2 -> 0.17.3 ``                                                     |
| [`7805c282`](https://github.com/NixOS/nixpkgs/commit/7805c2823deebfe3ae6a19b2f6cddb183afa4dee) | `` python312Packages.playwrightcapture: 1.24.3 -> 1.24.4 ``                           |
| [`a39dae03`](https://github.com/NixOS/nixpkgs/commit/a39dae03789394d60eea13b9251cfd1a2a4d103f) | `` python312Packages.microsoft-kiota-serialization-json: 1.1.0 -> 1.2.0 ``            |
| [`093452c8`](https://github.com/NixOS/nixpkgs/commit/093452c8275ea957a927700b5cf5e1553ea99642) | `` php82Extensions.xdebug: 3.3.1 -> 3.3.2 ``                                          |
| [`1d84c76f`](https://github.com/NixOS/nixpkgs/commit/1d84c76f5c4f1cb710a250faca3ecc80a1edb9d1) | `` nixos/nh: init ``                                                                  |
| [`1cbb0660`](https://github.com/NixOS/nixpkgs/commit/1cbb066095f6fd25ff770f08287e18b0d24c2b3c) | `` kubo: 0.27.0 -> 0.28.0 ``                                                          |
| [`51af928d`](https://github.com/NixOS/nixpkgs/commit/51af928dececa60ead6a811e1899e4974b90e8b7) | `` ft2-clone: 1.80 -> 1.82 ``                                                         |
| [`14066b78`](https://github.com/NixOS/nixpkgs/commit/14066b7892bce539b6dce43dad5f320d4d81ab54) | `` gqlgenc: 0.19.3 -> 0.20.0 ``                                                       |
| [`e72f5dc4`](https://github.com/NixOS/nixpkgs/commit/e72f5dc40e319b150098b6dc29017790c6f32ab0) | `` kitty: 0.33.1 -> 0.34.0 ``                                                         |
| [`674f2a0d`](https://github.com/NixOS/nixpkgs/commit/674f2a0dd66e63c99b3ec50244d01d23990e7775) | `` cargo-expand: 1.0.82 -> 1.0.84 ``                                                  |
| [`5dccc921`](https://github.com/NixOS/nixpkgs/commit/5dccc92115d4d7e3ef69a83f5aa96dd404580b99) | `` smassh: init at 3.1.3 ``                                                           |
| [`c230c3ec`](https://github.com/NixOS/nixpkgs/commit/c230c3ecc26a8390b94e7202769365c4ef93b8e2) | `` sunshine: 0.22.2 -> 0.23.0 ``                                                      |
| [`d05c932a`](https://github.com/NixOS/nixpkgs/commit/d05c932ab21541c2bbe91a04e1d70ce8d439f18a) | `` maintainers: add aimpizza ``                                                       |
| [`6a8ead5e`](https://github.com/NixOS/nixpkgs/commit/6a8ead5e3e3d8d60edc6160eb7d74c30f9a2edbd) | `` kdepim-runtime: use XOAUTH2 SASL plugin from libkgapi ``                           |
| [`e2ae18a7`](https://github.com/NixOS/nixpkgs/commit/e2ae18a7f34910631c5465337862801ea35d53de) | `` walker: 0.0.68 -> 0.0.70 ``                                                        |
| [`cde53c12`](https://github.com/NixOS/nixpkgs/commit/cde53c12dcdc559b8f918957cb6c975e22575f17) | `` gnomeExtensions: remove GNOME 46 extensions from the default set ``                |
| [`43487d0f`](https://github.com/NixOS/nixpkgs/commit/43487d0f4b75e94fdb7a6da6083d4a7fc2655c53) | `` fixup! goose: update test skip list with newer tests ``                            |
| [`fde3861f`](https://github.com/NixOS/nixpkgs/commit/fde3861f2109c4cd80c5fe6ba3aec827762cdb63) | `` wrapCC: check darwin-ness for -mcpu/-march based on targetPlatform ``              |
| [`9ba7ce51`](https://github.com/NixOS/nixpkgs/commit/9ba7ce51e223433f265b1673fd308838c7bfe93d) | `` goose: update test skip list with newer tests ``                                   |
| [`a227e07e`](https://github.com/NixOS/nixpkgs/commit/a227e07e6d4681a2bddcc65a55dc89bc9e3d4162) | `` poethepoet: 0.25.0 -> 0.25.1 ``                                                    |
| [`57695af4`](https://github.com/NixOS/nixpkgs/commit/57695af495e85a1ac6ef8d4f4d1f7c6aeb9802a0) | `` deck: 1.36.2 -> 1.37.0 ``                                                          |
| [`908d0fba`](https://github.com/NixOS/nixpkgs/commit/908d0fba851762ffb41750f0df7fd82d55db3d05) | `` uplosi: 0.1.3 -> 0.2.0 ``                                                          |
| [`0e9b76df`](https://github.com/NixOS/nixpkgs/commit/0e9b76dfa246b840f9946624a71adb41280b7aae) | `` crunchy-cli: 3.3.4 -> 3.4.3 ``                                                     |
| [`c803cb68`](https://github.com/NixOS/nixpkgs/commit/c803cb688fcdc76ce198e181e7fe81ffd92af6a2) | `` botan: 3.3.0 -> 3.4.0 ``                                                           |
| [`67c8efa6`](https://github.com/NixOS/nixpkgs/commit/67c8efa67e783492a349e7ccae5fc90e1312002e) | `` retroarch-joypad-autoconfig: 1.18.0 -> 1.18.1 ``                                   |
| [`b3c00684`](https://github.com/NixOS/nixpkgs/commit/b3c0068460df9529b2b7cb305d7002c8c828f0fb) | `` libretro.flycast: unstable-2024-04-05 -> unstable-2024-04-12 ``                    |
| [`96f0b95b`](https://github.com/NixOS/nixpkgs/commit/96f0b95bfec4cc6198cdf5e6c58f3b260f31c663) | `` libretro.mame: unstable-2024-04-05 -> unstable-2024-04-10 ``                       |
| [`1b411ccb`](https://github.com/NixOS/nixpkgs/commit/1b411ccbf39a1971cdb5bf809806c4c395d1bb24) | `` coqPackages.stdpp: 1.9.0 → 1.10.0 ``                                               |
| [`78945a82`](https://github.com/NixOS/nixpkgs/commit/78945a827cc5f2e5b97b7ca9807f7ac111086a1e) | `` stdenv: make inputDerivation never fixed-output ``                                 |
| [`301408fa`](https://github.com/NixOS/nixpkgs/commit/301408fab263d90d0e1b88f6cea00cb6d45aa531) | `` libretro.fbneo: unstable-2024-04-08 -> unstable-2024-04-15 ``                      |
| [`7a2ab79b`](https://github.com/NixOS/nixpkgs/commit/7a2ab79b5b1316139465f07d9d7bcaa469f155b4) | `` libretro.puae: unstable-2024-02-22 -> unstable-2024-04-12 ``                       |
| [`d4121f21`](https://github.com/NixOS/nixpkgs/commit/d4121f21d3ce8e31f7260ab738e2a71c0e6f3530) | `` libretro.ppsspp: unstable-2024-04-09 -> unstable-2024-04-14 ``                     |
| [`61312c18`](https://github.com/NixOS/nixpkgs/commit/61312c1890f8cca78a84d4ca26644bb3146e973c) | `` libretro.mame2003-plus: unstable-2024-04-09 -> unstable-2024-04-13 ``              |
| [`3559b8b0`](https://github.com/NixOS/nixpkgs/commit/3559b8b023d01db2d9abde1f3c552ffebdd7b024) | `` libretro.pcsx-rearmed: unstable-2024-04-06 -> unstable-2024-04-14 ``               |
| [`415a7526`](https://github.com/NixOS/nixpkgs/commit/415a7526a7507b0bf26a4ac77c0cd427a437ea01) | `` libretro.beetle-psx-hw: unstable-2024-03-22 -> unstable-2024-04-12 ``              |
| [`153de634`](https://github.com/NixOS/nixpkgs/commit/153de63415d8ca5a0b9fe0272c49e4c0d6c28016) | `` libretro.snes9x: unstable-2024-02-14 -> unstable-2024-04-13 ``                     |
| [`e5f757e7`](https://github.com/NixOS/nixpkgs/commit/e5f757e73a11d16a1df10e080bf69c1a245a0b56) | `` pkg-pferd: 3.5.1 -> 3.5.2 ``                                                       |
| [`97b7295e`](https://github.com/NixOS/nixpkgs/commit/97b7295ed419640c925a3fe0fbaa0aeacc3072d4) | `` libretro.play: unstable-2024-04-09 -> unstable-2024-04-10 ``                       |
| [`ab04c487`](https://github.com/NixOS/nixpkgs/commit/ab04c48766c67b36a10512b1e08514ec59f6ac41) | `` python312Packages.tencentcloud-sdk-python: 3.0.1128 -> 3.0.1129 ``                 |
| [`d83b4d18`](https://github.com/NixOS/nixpkgs/commit/d83b4d189b6b566413ef9eb3814fdecceb702e6d) | `` python312Packages.llama-index-readers-file: 0.1.17 -> 0.1.18 ``                    |
| [`540f28fb`](https://github.com/NixOS/nixpkgs/commit/540f28fb869152b1b5fc316458ebb75c942d78be) | `` python312Packages.llama-parse: 0.4.0 -> 0.4.1 ``                                   |
| [`4a4d98d9`](https://github.com/NixOS/nixpkgs/commit/4a4d98d961953fbb9b7d6313833e1cc69fb3b612) | `` python312Packages.soco: format with nixfmt ``                                      |
| [`a589919c`](https://github.com/NixOS/nixpkgs/commit/a589919cb3949c24a0fc2c3c84d251a4d9098971) | `` python312Packages.soco: 0.30.2 -> 0.30.3 ``                                        |
| [`6c627445`](https://github.com/NixOS/nixpkgs/commit/6c627445817f092f4ebc1611b619c231510d7c0e) | `` python312Packages.soco: refactor ``                                                |
| [`dfe8984a`](https://github.com/NixOS/nixpkgs/commit/dfe8984ad48a19eb4b92813c1b0d0135ac24553c) | `` pixi: 0.17.1 -> 0.19.1 ``                                                          |
| [`e6afeada`](https://github.com/NixOS/nixpkgs/commit/e6afeada62ae43494168ffda167edd14648404e0) | `` fluent-bit: 3.0.1 -> 3.0.2 ``                                                      |
| [`88b93829`](https://github.com/NixOS/nixpkgs/commit/88b93829d9549c6fc83a8db777985f13456c1191) | `` netbird-ui: 0.27.2 -> 0.27.3 ``                                                    |
| [`b941d525`](https://github.com/NixOS/nixpkgs/commit/b941d525061a6e4f43882318225799c901f1ad40) | `` jasmin-compiler: 2023.06.2 → 2023.06.3 ``                                          |
| [`4b6f17a8`](https://github.com/NixOS/nixpkgs/commit/4b6f17a8a68cea10a618681a8163fbc02d30e1cc) | `` dune_3: 3.14.2 -> 3.15.0 ``                                                        |
| [`a46df739`](https://github.com/NixOS/nixpkgs/commit/a46df739b622b48333de8e1cb9fb07f3a41d99da) | `` subxt: 0.35.2 -> 0.35.3 ``                                                         |
| [`eb6aac6a`](https://github.com/NixOS/nixpkgs/commit/eb6aac6a739cad3db2b1b0a0686839dbfcea1274) | `` ocamlPackages.miou: init at 0.1.0 ``                                               |
| [`38b8f65d`](https://github.com/NixOS/nixpkgs/commit/38b8f65d4c5370d177bfb4ddbef1e2e96f39fb33) | `` iredis: fix build on x86_64-darwin ``                                              |
| [`cbb6e81f`](https://github.com/NixOS/nixpkgs/commit/cbb6e81fff98b891f45087e8f664035859ef7aa9) | `` python311Packages.internetarchive: 3.7.0 -> 4.0.1 ``                               |
| [`5385c6ee`](https://github.com/NixOS/nixpkgs/commit/5385c6eec1f73abfa9f0c48719df0dfe7440f218) | `` twitch-dl: 2.1.4 -> 2.2.0 ``                                                       |
| [`8f4266af`](https://github.com/NixOS/nixpkgs/commit/8f4266af56e3b1f361c71a1367904c4c8049f283) | `` luau: 0.620 -> 0.621 ``                                                            |
| [`f8b08359`](https://github.com/NixOS/nixpkgs/commit/f8b0835980b540fc6c765252ee80cfbef31ae4da) | `` nodejs_18: 18.20.1 -> 18.20.2 ``                                                   |
| [`a69122c3`](https://github.com/NixOS/nixpkgs/commit/a69122c37de6c44e6beaf6b95dab312f53ac741d) | `` iredis: update meta ``                                                             |
| [`86be7391`](https://github.com/NixOS/nixpkgs/commit/86be7391aa273f5f652dd4d2d9595d5e643eaeca) | `` twitch-dl: migrate to pkgs/by-name ``                                              |
| [`180cf46b`](https://github.com/NixOS/nixpkgs/commit/180cf46b4c0bc2edce78db2a5fef601103826699) | `` iredis: 1.14.1 -> 1.15.0 ``                                                        |
| [`5b07b100`](https://github.com/NixOS/nixpkgs/commit/5b07b1005bde41926e4645645fb3302a733ccbfc) | `` iredis: migrate to by-name ``                                                      |
| [`638ea467`](https://github.com/NixOS/nixpkgs/commit/638ea4677efcd23fdc7896f71c21860fd9fcecfe) | `` python312Packages.goodwe: 0.3.2 -> 0.3.3 ``                                        |
| [`e91467c3`](https://github.com/NixOS/nixpkgs/commit/e91467c3ac90158d56bed52c43ac6c0cdc7a88bc) | `` ocamlPackages.owee: 0.6 → 0.7 ``                                                   |