### PR TITLE
chore(flake/nixpkgs): `6143fc5e` -> `572af610`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713714899,
-        "narHash": "sha256-+z/XjO3QJs5rLE5UOf015gdVauVRQd2vZtsFkaXBq2Y=",
+        "lastModified": 1713895582,
+        "narHash": "sha256-cfh1hi+6muQMbi9acOlju3V1gl8BEaZBXBR9jQfQi4U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6143fc5eeb9c4f00163267708e26191d1e918932",
+        "rev": "572af610f6151fd41c212f897c71f7056e3fb518",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`3257ce1b`](https://github.com/NixOS/nixpkgs/commit/3257ce1b8672a6f2ff0a46f079ed7f28839de63e) | `` matrix-synapse: 1.105.0 -> 1.105.1 ``                                     |
| [`b3431dd5`](https://github.com/NixOS/nixpkgs/commit/b3431dd54d649ae22dd6f565f7c7327570ac501a) | `` tmuxPlugins.nord: update repo and metadata (#290575) ``                   |
| [`120be137`](https://github.com/NixOS/nixpkgs/commit/120be1377861f3d7053f9f5d451963d90b9f5231) | `` python3Packages.numba: don't default to obsolete shellhooks ``            |
| [`e660db32`](https://github.com/NixOS/nixpkgs/commit/e660db3233b27da48d52be2c1a0931fc2e304836) | `` docs/cuda: remove last references to cudaPackages.autoAddDriverRunpath `` |
| [`75110f8b`](https://github.com/NixOS/nixpkgs/commit/75110f8b6d86fddb37766b4a30901bd08471e020) | `` ranger: 1.9.3 -> 1.9.3-unstable-2023-08-23 (#280143) ``                   |
| [`c4168ca6`](https://github.com/NixOS/nixpkgs/commit/c4168ca616671849ad7e8b05e552862954bd3e6d) | `` sage: Fix test failure from scipy upgrade ``                              |
| [`90b06e37`](https://github.com/NixOS/nixpkgs/commit/90b06e372c9eb1a1029957b93cb81e1a7fe366cc) | `` cinnamon.mint-l-icons: 1.6.7 -> 1.7.0 ``                                  |
| [`2b870872`](https://github.com/NixOS/nixpkgs/commit/2b8708729a1ab018309a8efe4bdb168035fcd1e6) | `` cinnamon.mint-y-icons: 1.7.2 -> 1.7.5 ``                                  |
| [`232aa867`](https://github.com/NixOS/nixpkgs/commit/232aa8677c2ce546291cf76252a6d17ca8c3a322) | `` cinnamon.mint-x-icons: 1.6.5 -> 1.6.8 ``                                  |
| [`a876233b`](https://github.com/NixOS/nixpkgs/commit/a876233b9a622e750e7990d0304f3a00a1e4392d) | `` luaPackages.lua-resty-core: 0.1.24 -> 0.1.28 ``                           |
| [`4c4df476`](https://github.com/NixOS/nixpkgs/commit/4c4df4766a584111edb8b5fd50ee35b50a95b51c) | `` gnomeExtensions: auto-update ``                                           |
| [`489b2faa`](https://github.com/NixOS/nixpkgs/commit/489b2faaec829911897fc325f1143467aabece50) | `` fits-cloudctl: 0.12.17 -> 0.12.18 ``                                      |
| [`146fe35b`](https://github.com/NixOS/nixpkgs/commit/146fe35bbe2b0b14eea2bae5a43b441a1783f439) | `` sublime-merge: 2091 → 2096 ``                                             |
| [`c9368733`](https://github.com/NixOS/nixpkgs/commit/c93687339809d49501fd9351fef166a2a2ffb608) | `` sublime-merge-dev: 2094 → 2095 ``                                         |
| [`0c4ac12c`](https://github.com/NixOS/nixpkgs/commit/0c4ac12c32683c3d9f95cfe3ce047fc87aa7d8b3) | `` wrap-terminal: fix eval ``                                                |
| [`069df9cb`](https://github.com/NixOS/nixpkgs/commit/069df9cb6abfa1f7e8b93f64a658381a8b4df189) | `` python3Packages.manga-ocr: init at 0.1.11 ``                              |
| [`41facdab`](https://github.com/NixOS/nixpkgs/commit/41facdabebd7caa5dddfb86a82f212d628944b92) | `` intel-media-driver: 23.4.3 -> 24.2.1 (#306060) ``                         |
| [`51578032`](https://github.com/NixOS/nixpkgs/commit/51578032dd489369a698022dfbdf80b92d161123) | `` kdePackages.kwin: 6.0.4 -> 6.0.4.1 ``                                     |
| [`b2b4e073`](https://github.com/NixOS/nixpkgs/commit/b2b4e0739cd797a4b7725ecaea0a191e42c1934a) | `` python311Packages.mdformat-mkdocs: 2.0.8 -> 2.0.9 ``                      |
| [`e84bb298`](https://github.com/NixOS/nixpkgs/commit/e84bb298e02203ea92a589caf2d1ee02a0266b96) | `` roadrunner: 2023.3.12 -> 2024.1.0 ``                                      |
| [`7264d7e5`](https://github.com/NixOS/nixpkgs/commit/7264d7e5f8b36460b4da969d9ae0b91eca55c011) | `` vimPlugins.nvim-sops: init at 2024-04-23 ``                               |
| [`8541ec6d`](https://github.com/NixOS/nixpkgs/commit/8541ec6d85c40dad2841642aa16ab8b3a2f97d53) | `` nixos/incus: add support for software TPMs ``                             |
| [`7810d896`](https://github.com/NixOS/nixpkgs/commit/7810d896644bbd6ad8fc03fb98e29c49489c2ee1) | `` blackfire: 2.26.3 -> 2.26.4 ``                                            |
| [`d1ba45bf`](https://github.com/NixOS/nixpkgs/commit/d1ba45bfb50b0498440bc0750ccc3d6b0b4acf87) | `` v2ray: 5.15.1 -> 5.15.3 ``                                                |
| [`0219cfd0`](https://github.com/NixOS/nixpkgs/commit/0219cfd0ae52d76921ce385f2cd55451a3827f76) | `` pt2-clone: 1.67 -> 1.68 ``                                                |
| [`b0bfbeb4`](https://github.com/NixOS/nixpkgs/commit/b0bfbeb4e088244893f6cd5c068ee9dd2189bd5c) | `` invidious: 0.20.1-unstable-2024-03-31 -> 0.20.1-unstable-2024-04-10 ``    |
| [`41128527`](https://github.com/NixOS/nixpkgs/commit/4112852702b2db5f0ab6083734c0bdd325595771) | `` kubernetes: 1.29.4 -> 1.30.0 ``                                           |
| [`1cd36a7b`](https://github.com/NixOS/nixpkgs/commit/1cd36a7b6cdaf56e62c747e505986787f44ef24e) | `` hugo: 0.125.0 -> 0.125.3 ``                                               |
| [`037f1875`](https://github.com/NixOS/nixpkgs/commit/037f1875b15e09ef04c080d1fd212dc045e6cdd4) | `` netscanner: 0.4.2 -> 0.4.4 ``                                             |
| [`68a917dc`](https://github.com/NixOS/nixpkgs/commit/68a917dc6480b8ab79c57df265916d35ab9c01c2) | `` nixos/coder: fix broken service by referencing proper env (#305993) ``    |
| [`83b4b612`](https://github.com/NixOS/nixpkgs/commit/83b4b6129a8bceaa37bcd8fdf4155b333bde27d2) | `` mdbook-epub: unstable-2022-12-25 -> 0.4.37 ``                             |
| [`2d22ed27`](https://github.com/NixOS/nixpkgs/commit/2d22ed278a6d52ae6a8caead54ad682c58633094) | `` nix-eval-jobs: 2.19.4 -> 2.21.0 ``                                        |
| [`8420bae6`](https://github.com/NixOS/nixpkgs/commit/8420bae6105680deae07dc4bb634b77df011b864) | `` ber_metaocaml: 111 -> 114 (#303529) ``                                    |
| [`5639d22c`](https://github.com/NixOS/nixpkgs/commit/5639d22cf703156df6db3a93d232c0ea56485c48) | `` python312Packages.azure-cosmos: format with nixfmt ``                     |
| [`3d27edc7`](https://github.com/NixOS/nixpkgs/commit/3d27edc7ae973c4cc52f183b069bad292608ab07) | `` python312Packages.azure-cosmos: refactor ``                               |
| [`f747fb39`](https://github.com/NixOS/nixpkgs/commit/f747fb392392211fbecec1b28078e609002dcfc8) | `` awslimitchecker: format with nixfmt ``                                    |
| [`9e9aa732`](https://github.com/NixOS/nixpkgs/commit/9e9aa732af490e43662e30e9872b569a10c3e2ed) | `` awslimitchecker: refactor ``                                              |
| [`d7a720ef`](https://github.com/NixOS/nixpkgs/commit/d7a720efca55299dcb6a2aa9a687b17ced6ea42c) | `` python312Packages.aiounifi: 75 -> 76 ``                                   |
| [`738e6665`](https://github.com/NixOS/nixpkgs/commit/738e6665050fbd24e6d26ec410c56c7179b5f418) | `` python312Packages.aioeagle: format with nixfmt ``                         |
| [`722c517b`](https://github.com/NixOS/nixpkgs/commit/722c517b1dff3229c424c31cbf6c52986097f574) | `` python312Packages.aioeagle: refactor ``                                   |
| [`8748ff8a`](https://github.com/NixOS/nixpkgs/commit/8748ff8ae8b26ba3d99aa14a2e4dc69507e9baf3) | `` python312Packages.onetimepass: format with nixfmt ``                      |
| [`b0cfbcb1`](https://github.com/NixOS/nixpkgs/commit/b0cfbcb15991b7e01d9739e23925e1c98433c49c) | `` python312Packages.onetimepass: refactor ``                                |
| [`7a4f45d7`](https://github.com/NixOS/nixpkgs/commit/7a4f45d7cf88320c487540c032b42acf53bacdf8) | `` python312Packages.timecop: format with nixfmt ``                          |
| [`c5010efa`](https://github.com/NixOS/nixpkgs/commit/c5010efa1f3b5d8a27bce0eca2ec0244a8cec8f2) | `` python312Packages.timecop: refactor ``                                    |
| [`cf9948c3`](https://github.com/NixOS/nixpkgs/commit/cf9948c3f6d18112f33ad88cc0bd49cc95ba6531) | `` dracula-theme: unstable-2024-04-08 -> unstable-2024-04-16 ``              |
| [`f3d0985a`](https://github.com/NixOS/nixpkgs/commit/f3d0985a0818d5f6df073c592944bf99008d9f1a) | `` python312Packages.awswrangler: refactor ``                                |
| [`31748b91`](https://github.com/NixOS/nixpkgs/commit/31748b91a2c16d2404f14f893fe2d6bed8e73f8e) | `` python311Packages.awswrangler: format with nixfmt ``                      |
| [`b34f1264`](https://github.com/NixOS/nixpkgs/commit/b34f1264706e1449e836de4b2a9d6bb8b76a90a2) | `` python312Packages.zha: 0.0.5 -> 0.0.8 ``                                  |
| [`10cf59f9`](https://github.com/NixOS/nixpkgs/commit/10cf59f9a1897dcd5cd1725eeca52272d17a3756) | `` python312Packages.crc: format with nixfmt ``                              |
| [`eca2e572`](https://github.com/NixOS/nixpkgs/commit/eca2e5722b9d045b927fb83d6dfd355bcd73bbe6) | `` python312Packages.crc: refactor ``                                        |
| [`8be3014c`](https://github.com/NixOS/nixpkgs/commit/8be3014c36d9e0522977b23b94bced1e7881df18) | `` python311Packages.clarifai-grpc: 10.3.0 -> 10.3.2 ``                      |
| [`569e7753`](https://github.com/NixOS/nixpkgs/commit/569e7753914698ece68b7e373311ea8795c1a7d9) | `` microsoft-edge: 123.0.2420.97 -> 124.0.2478.51 ``                         |
| [`33dc1f9e`](https://github.com/NixOS/nixpkgs/commit/33dc1f9e579a42b05c37aed242a95c9acf457606) | `` python312Packages.llama-index-vector-stores-qdrant: 0.2.4 -> 0.2.5 ``     |
| [`d94f14c3`](https://github.com/NixOS/nixpkgs/commit/d94f14c3b9af61ab87a5d3f2e18728590c7ff3c1) | `` python312Packages.llama-index-vector-stores-qdrant: 0.2.3 -> 0.2.4 ``     |
| [`c2cd826e`](https://github.com/NixOS/nixpkgs/commit/c2cd826e236d7a25864e616844667e39e915146f) | `` python312Packages.llama-index-vector-stores-qdrant: 0.2.1 -> 0.2.3 ``     |
| [`7ce7e290`](https://github.com/NixOS/nixpkgs/commit/7ce7e29051ab743aa6b2c68af0cef1c71750bf8d) | `` python312Packages.llama-index-agent-openai: 0.2.2 -> 0.2.3 ``             |
| [`3f5b73f9`](https://github.com/NixOS/nixpkgs/commit/3f5b73f97707c18e83cece9e149039495bd5892a) | `` python311Packages.spacy: mark as broken ``                                |
| [`659817a5`](https://github.com/NixOS/nixpkgs/commit/659817a5320bcde67feb9d97c918d46855f09f16) | `` python311Packages.imageio: 2.34.0 -> 2.34.1 ``                            |
| [`4945c0d3`](https://github.com/NixOS/nixpkgs/commit/4945c0d38567ec01f0585c0300dea38d140ae070) | `` python311Packages.pydrawise: format with nixfmt ``                        |
| [`ccc52175`](https://github.com/NixOS/nixpkgs/commit/ccc521756cbd3c8792ab0afeb8a4eb5eda9d2cec) | `` python311Packages.pydrawise: refactor ``                                  |
| [`4bcd6b5a`](https://github.com/NixOS/nixpkgs/commit/4bcd6b5ad3e95c51bbe1310b3b0ad33448078900) | `` sqlite3-to-mysql: 2.1.8 -> 2.1.9 ``                                       |
| [`db92283e`](https://github.com/NixOS/nixpkgs/commit/db92283eff575ac2a78d7b2d65d2dad4f7acf14a) | `` waybar: 0.10.0 -> 0.10.1 ``                                               |
| [`f8d3ea20`](https://github.com/NixOS/nixpkgs/commit/f8d3ea2062a6c6ebf6d823de71392144de0843b2) | `` codeium: 1.8.25 -> 1.8.27 ``                                              |
| [`03cef041`](https://github.com/NixOS/nixpkgs/commit/03cef041d7f2a38d599641d0225eec353cfcd994) | `` eigenmath: unstable-2024-04-08 -> unstable-2024-04-19 ``                  |
| [`9e5f017e`](https://github.com/NixOS/nixpkgs/commit/9e5f017ecc2cd7d555b88f39888cd71a7e5c90d2) | `` adbtuifm: shorten meta.description attribute ``                           |
| [`6f257b6d`](https://github.com/NixOS/nixpkgs/commit/6f257b6d5ab1545713301cd215c3a57a41facbdf) | `` adbtuifm: remove android-tools build input ``                             |
| [`a4d4799f`](https://github.com/NixOS/nixpkgs/commit/a4d4799fbd953516c777ca460b0d22e719be14f9) | `` yamlscript: 0.1.56 -> 0.1.57 ``                                           |
| [`118f9bd2`](https://github.com/NixOS/nixpkgs/commit/118f9bd2bd9c13075601dabe860d10dbd89de4e5) | `` vscode-extensions.nvarner.typst-lsp: 0.12.1 -> 0.13.0 ``                  |
| [`3105f53d`](https://github.com/NixOS/nixpkgs/commit/3105f53d4c495f6ded1fc14b35ad4cd0df6745c3) | `` uv: 0.1.35 -> 0.1.36 ``                                                   |
| [`f17136e4`](https://github.com/NixOS/nixpkgs/commit/f17136e4b2830eb2baa920345bd6f7c60812a3de) | `` git-mit: 5.12.196 -> 5.12.197 ``                                          |
| [`cb4a3e62`](https://github.com/NixOS/nixpkgs/commit/cb4a3e62f7f3377dbdf4d0dddb3d7c6e9aa8ff62) | `` bruno: 1.13.1 -> 1.14.0 ``                                                |
| [`265ed46b`](https://github.com/NixOS/nixpkgs/commit/265ed46b853a3f75e4a2d6567de3de8827489d46) | `` python311Packages.pydrawise: 2024.3.0 -> 2024.4.0 ``                      |
| [`2eee5fcc`](https://github.com/NixOS/nixpkgs/commit/2eee5fcc2a5f87bd7a75bdac7f4b436613c67bc4) | `` nixd: add version and pkg-config testers ``                               |
| [`c1f5835e`](https://github.com/NixOS/nixpkgs/commit/c1f5835e6ba8b2df709d51fa0e81b1f51fd7105c) | `` nixd: use finalAttrs pattern ``                                           |
| [`d69a2737`](https://github.com/NixOS/nixpkgs/commit/d69a2737c485234f8f8cba94577fe43239fa533f) | `` nixd: 1.2.3 -> 2.0.2 ``                                                   |
| [`616be978`](https://github.com/NixOS/nixpkgs/commit/616be9785f91100fa43ebb2daa8ef23a01dcfb41) | `` smpq: pin stormlib to version 9.22 ``                                     |
| [`95642f47`](https://github.com/NixOS/nixpkgs/commit/95642f474c4ed16619f472cd2578e680eb0f927f) | `` stormlib: mark as broken on Darwin ``                                     |
| [`2502dd75`](https://github.com/NixOS/nixpkgs/commit/2502dd75bd0ff78243562a97ddf15a6d8820538e) | `` stormlib: 9.22 -> 9.23 ``                                                 |
| [`a630b7d2`](https://github.com/NixOS/nixpkgs/commit/a630b7d254a7a6f7fb0ffaf894aa499286aa6730) | `` stormlib: refactor ``                                                     |
| [`37d8b499`](https://github.com/NixOS/nixpkgs/commit/37d8b499a0ef3d9b5807fb5af79df4dfd8c44133) | `` smpq: refactor ``                                                         |
| [`03d84869`](https://github.com/NixOS/nixpkgs/commit/03d84869b01a72203785e25fce64c2ecca6ee0ba) | `` smpq: migrate to by-name ``                                               |
| [`cabaa9ba`](https://github.com/NixOS/nixpkgs/commit/cabaa9badac141ba10eada6aef52951813f9d3ac) | `` storj-uplink: 1.102.2 -> 1.102.4 ``                                       |
| [`efc395b9`](https://github.com/NixOS/nixpkgs/commit/efc395b921d04eee060b50dc890ef5b9d6d4cb33) | `` heroku: 8.11.2 -> 8.11.4 ``                                               |
| [`8fd173c9`](https://github.com/NixOS/nixpkgs/commit/8fd173c977e7656599693998fb2bde942aed0afc) | `` atac: add SystemConfiguration framework as a dependency on Darwin ``      |
| [`5226b3d2`](https://github.com/NixOS/nixpkgs/commit/5226b3d29c585bf644e59d99e0a221c96dde4f4f) | `` cnquery: 10.12.2 -> 11.0.2 ``                                             |
| [`dcc2d856`](https://github.com/NixOS/nixpkgs/commit/dcc2d8569fc9f84dcc6638ceb2d3823f963bba3b) | `` simdutf: 5.2.4 -> 5.2.5 ``                                                |
| [`ba79f5df`](https://github.com/NixOS/nixpkgs/commit/ba79f5dfb37d8ad9db2e6bc464b43e6baa0c7b93) | `` terraform-ls: 0.33.0 -> 0.33.1 ``                                         |
| [`2ebdbcf9`](https://github.com/NixOS/nixpkgs/commit/2ebdbcf97410c8de3e76a5ed61595d471a02b7bf) | `` rqlite: 8.23.1 -> 8.23.2 ``                                               |
| [`6554f493`](https://github.com/NixOS/nixpkgs/commit/6554f4939cf7b5e4ee1b395827f534c8cf333ca6) | `` telegraf: 1.30.1 -> 1.30.2 ``                                             |
| [`cd5dd838`](https://github.com/NixOS/nixpkgs/commit/cd5dd83807b42508a3ebee31389694f33e5e52fe) | `` xmake: 2.8.9 -> 2.9.1 ``                                                  |
| [`60ef683c`](https://github.com/NixOS/nixpkgs/commit/60ef683c62b5918d4895eadab33d9922f77bcbb7) | `` uxplay: 1.68.2 -> 1.68.3 ``                                               |
| [`473b0522`](https://github.com/NixOS/nixpkgs/commit/473b052240e221866c1688f311f49f69f349c80d) | `` lact: 0.5.3 -> 0.5.4 ``                                                   |
| [`c34da842`](https://github.com/NixOS/nixpkgs/commit/c34da8426192e341893b1ae79b545696c8fd99a6) | `` fgqcanvas: Init at 0-unstable-2024-02-11 ``                               |
| [`f685a631`](https://github.com/NixOS/nixpkgs/commit/f685a63133f8c87962626710f8d7344ae3bcf60a) | `` vscode-extensions.ms-python.vscode-pylance: 2023.8.50 -> 2024.4.1 ``      |
| [`01494761`](https://github.com/NixOS/nixpkgs/commit/01494761f62b13cb07b06684dd6d53e19b06a471) | `` vscode-extensions.hiukky.flate: init at 0.7.0 ``                          |
| [`ceead2d7`](https://github.com/NixOS/nixpkgs/commit/ceead2d7e4bea5f5f668b9c57952d95a5cfbaa43) | `` azure-cli: document extensions in description, fix release notes ``       |
| [`90653e46`](https://github.com/NixOS/nixpkgs/commit/90653e46d2bfbcfe470f60cb4685dc21a4f73e5e) | `` istioctl: 1.21.1 -> 1.21.2 ``                                             |
| [`140d47da`](https://github.com/NixOS/nixpkgs/commit/140d47dacccde4dfe9eace5859ccf7d240a5887c) | `` python311Packages.plantuml-markdown: 3.9.4 -> 3.9.5 ``                    |
| [`734bf513`](https://github.com/NixOS/nixpkgs/commit/734bf5136ce4bec47759b02e3d015963b99c955b) | `` chaos: 0.5.1 -> 0.5.2 ``                                                  |
| [`210f7a61`](https://github.com/NixOS/nixpkgs/commit/210f7a618a807d75da176aac76f9cbabc710cb53) | `` home-assistant: update component packages ``                              |
| [`5a1d3940`](https://github.com/NixOS/nixpkgs/commit/5a1d3940b8014f109bd9c0e92d2a18f4642ccaae) | `` python312Packages.python-homeassistant-analytics: init at 0.6.0 ``        |
| [`10d9c681`](https://github.com/NixOS/nixpkgs/commit/10d9c681d0f00dc273397e6032d26c3799e1653a) | `` checkov: 3.2.72 -> 3.2.74 ``                                              |
| [`dd159fd2`](https://github.com/NixOS/nixpkgs/commit/dd159fd21ae9f0005226198920524fe30acb90bb) | `` trivy: format with nixfmt ``                                              |
| [`c50d0c55`](https://github.com/NixOS/nixpkgs/commit/c50d0c558f41aa7559379170b1fa4f37e02c2671) | `` python312Packages.pick: format with nixfmt ``                             |
| [`5a6bca95`](https://github.com/NixOS/nixpkgs/commit/5a6bca95377da50660568f6c593fb41b3d8070bb) | `` python312Packages.pick: refactor ``                                       |
| [`af04d1af`](https://github.com/NixOS/nixpkgs/commit/af04d1af2e54b8513049073c9cb58257c09b95db) | `` python312Packages.pick: 2.2.0 -> 2.3.0 ``                                 |
| [`f2059c61`](https://github.com/NixOS/nixpkgs/commit/f2059c619d5ea8b0d3a4d40319ce59a45bff751b) | `` notus-scanner: format with nixfmt ``                                      |
| [`d2213b78`](https://github.com/NixOS/nixpkgs/commit/d2213b78e87d74d0972048a34c28dab5362a1455) | `` notus-scanner: refactor ``                                                |
| [`4fc2a318`](https://github.com/NixOS/nixpkgs/commit/4fc2a318a70a2aae544d5e65a6ce65616a3e468c) | `` notus-scanner: 22.6.2 -> 22.6.3 ``                                        |
| [`1f0f9be4`](https://github.com/NixOS/nixpkgs/commit/1f0f9be46f13c145237d91062cf7ab14163672b7) | `` qovery-cli: 0.87.0 -> 0.89.0 ``                                           |
| [`5549846d`](https://github.com/NixOS/nixpkgs/commit/5549846d1889a7626909a336dbca4adb0516dbea) | `` trivy: 0.50.1 -> 0.50.2 ``                                                |
| [`9f3d24ec`](https://github.com/NixOS/nixpkgs/commit/9f3d24eccd79ef4c8726c971d76d644b72ce8d52) | `` tplay.meta.maintainers: add colemickens ``                                |
| [`1b8a657c`](https://github.com/NixOS/nixpkgs/commit/1b8a657cc0d5911932eb6d7f3cb1edff9eaac19e) | `` python311Packages.crc: 6.1.2 -> 7.0.0 ``                                  |
| [`ed914640`](https://github.com/NixOS/nixpkgs/commit/ed91464081e2486bfd90ddb87da96251baef9505) | `` python311Packages.snakemake: 8.10.6 -> 8.10.7 ``                          |
| [`7b67f660`](https://github.com/NixOS/nixpkgs/commit/7b67f66039cc9567cf72f86ad95519adc7badfc6) | `` autopsy: init at 4.21.0 ``                                                |
| [`100a740c`](https://github.com/NixOS/nixpkgs/commit/100a740c0fd7aa74f9168c07fa23f8fdc13fe19c) | `` audacious: add vgmstream plugin ``                                        |
| [`d90d1b70`](https://github.com/NixOS/nixpkgs/commit/d90d1b703c10c26cadf9ba58bc97c755106eed76) | `` inshellisense: 0.0.1-rc.12 -> 0.0.1-rc.14 ``                              |
| [`07f3a131`](https://github.com/NixOS/nixpkgs/commit/07f3a13157c65b871e701ecf1eefaa00cb34187a) | `` spamassassin: 4.0.0 -> 4.0.1 ``                                           |