### PR TITLE
chore(flake/nixpkgs): `062ca2a9` -> `20578140`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715447595,
-        "narHash": "sha256-VsVAUQOj/cS1LCOmMjAGeRksXIAdPnFIjCQ0XLkCsT0=",
+        "lastModified": 1715534503,
+        "narHash": "sha256-5ZSVkFadZbFP1THataCaSf0JH2cAH3S29hU9rrxTEqk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "062ca2a9370a27a35c524dc82d540e6e9824b652",
+        "rev": "2057814051972fa1453ddfb0d98badbea9b83c06",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`449b6c97`](https://github.com/NixOS/nixpkgs/commit/449b6c977e223aafc2d9ebda161f4e8cd3f13b15) | `` Remove fwam from the list of maintainers. ``                                     |
| [`b35ccb7f`](https://github.com/NixOS/nixpkgs/commit/b35ccb7fda289490130aa0372af05629174c2c11) | `` nixos/tests/misc: call the tester `test` to be `callTest`-ed ``                  |
| [`61aef87e`](https://github.com/NixOS/nixpkgs/commit/61aef87edd160b926bb455cc5d045fcb8afaddb0) | `` home-assistant: relax sqlachemy constraint ``                                    |
| [`feac6072`](https://github.com/NixOS/nixpkgs/commit/feac6072dc8768630e9f65d2adf9e4a9769e6b47) | `` glance: init at 0.3.0 ``                                                         |
| [`64e51577`](https://github.com/NixOS/nixpkgs/commit/64e51577b7dc2a19d1aac70903741bb6585ae734) | `` nixos/release-`*`: fix `nixos.tests.misc` which was split into multiple tests `` |
| [`500fb7e7`](https://github.com/NixOS/nixpkgs/commit/500fb7e7a9e14b441d3ead8a643700673e82d47a) | `` mpvScripts.modernx-zydezu: 0.2.9 -> 0.3.2 ``                                     |
| [`9fb809fc`](https://github.com/NixOS/nixpkgs/commit/9fb809fcd800dbe9b139a90908be4df430452686) | `` lib.maintainers: add `luftmensch-luftmensch` ``                                  |
| [`3592c63e`](https://github.com/NixOS/nixpkgs/commit/3592c63e3a01e6e6308fa1f7b6244b629e516169) | `` netbox_3_7: 3.7.4 -> 3.7.8 (#309483) ``                                          |
| [`333fdca4`](https://github.com/NixOS/nixpkgs/commit/333fdca4ddcf4e42ce86cdf70c255d409450fc79) | `` python312Packages.ansible-runner: fix build ``                                   |
| [`3de41ce7`](https://github.com/NixOS/nixpkgs/commit/3de41ce7a8bafa61c4840608e8c8f361c9c019b4) | `` nixos/mate: enable services.gnome.glib-networking ``                             |
| [`72bb21b1`](https://github.com/NixOS/nixpkgs/commit/72bb21b14b0148f277bce4eceb503cb65d5e47a4) | `` python312Packages.opuslib: fix build and tests ``                                |
| [`9175a5cc`](https://github.com/NixOS/nixpkgs/commit/9175a5cc1fb3c97ab2b915f7ff3fd9508fd250d1) | `` python312Packages.hid: disable tests, use pep517 builder ``                      |
| [`70736980`](https://github.com/NixOS/nixpkgs/commit/707369808137df4fcc2c5b3f7c4f6a762e816521) | `` python312Packages.lockfile: migrate to pynose and pep517 builder ``              |
| [`e9026e15`](https://github.com/NixOS/nixpkgs/commit/e9026e154565d75b1bbadeb9746a47888589eda4) | `` meteo: Add missing glib-networking ``                                            |
| [`4be421cc`](https://github.com/NixOS/nixpkgs/commit/4be421cc73f71e58681e9526d0ca7498b2488bed) | `` python312Packages.psycopg2cffi: 2.8.1 -> 2.9.0 ``                                |
| [`e24bc0e0`](https://github.com/NixOS/nixpkgs/commit/e24bc0e085b32b449b55840c3ac5425171aba0a8) | `` python312Packages.gemfileparser: format with nixfmt ``                           |
| [`a049660d`](https://github.com/NixOS/nixpkgs/commit/a049660d2033f6c330221886b9b20eb6a666a50e) | `` python312Packages.gemfileparser: refactor ``                                     |
| [`964f774e`](https://github.com/NixOS/nixpkgs/commit/964f774eeb8132eff7dc9d791591b729b6e3eb37) | `` python312Packages.oemthermostat: format with nixfmt ``                           |
| [`db4171f3`](https://github.com/NixOS/nixpkgs/commit/db4171f3e241b4562fd0c0f924c802e35a1ddcdd) | `` sarif-tools: init at 2.0.0 (#283208) ``                                          |
| [`01ec2ee0`](https://github.com/NixOS/nixpkgs/commit/01ec2ee0e7c1b3c6a872fd7fa8cd72b2a1298945) | `` python312Packages.oemthermostat: refactor ``                                     |
| [`5307ac27`](https://github.com/NixOS/nixpkgs/commit/5307ac27d74584e64679b57c6effe3615d764633) | `` mpvScripts.evafast: Specify upstream branch in `updateScript` (#309509) ``       |
| [`9e51cb7a`](https://github.com/NixOS/nixpkgs/commit/9e51cb7a10d86013a53a330c04403913ec543e63) | `` python312Packages.openwrt-ubus-rpc: format with nixfmt ``                        |
| [`a245b93e`](https://github.com/NixOS/nixpkgs/commit/a245b93ea6daa38d5602b4e026898355abfbc9e7) | `` python312Packages.openwrt-ubus-rpc: refactor ``                                  |
| [`c4b50d20`](https://github.com/NixOS/nixpkgs/commit/c4b50d203e9d7040ad7ec5d085d70aea1cd30218) | `` pidgin: fix build on darwin, add mainProgram ``                                  |
| [`1e88b22a`](https://github.com/NixOS/nixpkgs/commit/1e88b22aaf3fb81ed5b8f485442708c0b1ca8bc1) | `` python312Packages.noiseprotocol: format with nixfmt ``                           |
| [`a4a9a955`](https://github.com/NixOS/nixpkgs/commit/a4a9a955f7cec215aca9ef1ab2ff1701678c4b54) | `` python312Packages.noiseprotocol: refactor ``                                     |
| [`d1e92ca7`](https://github.com/NixOS/nixpkgs/commit/d1e92ca7115df154e21a0272872548cf3624ab63) | `` maintainers: add dvn0 ``                                                         |
| [`ad4b815f`](https://github.com/NixOS/nixpkgs/commit/ad4b815f320852c94c6335a71cec3e30eb2e2abd) | `` yarn-berry: 4.2.1 -> 4.2.2 ``                                                    |
| [`08a535ed`](https://github.com/NixOS/nixpkgs/commit/08a535edca3a05bad9090323071370b665462436) | `` taskwarrior-tui: 0.25.4 -> 0.26.0 ``                                             |
| [`7251e480`](https://github.com/NixOS/nixpkgs/commit/7251e4804b70b42b379531734cecd8fef60ef86b) | `` python312Packages.naturalsort: format with nixfmt ``                             |
| [`cceefc0e`](https://github.com/NixOS/nixpkgs/commit/cceefc0ee15ae3158be9c1739b6516d4367e473d) | `` python312Packages.naturalsort: refactor ``                                       |
| [`b69b3c14`](https://github.com/NixOS/nixpkgs/commit/b69b3c14a632ae34fcc579df1d1a20d07d1c73f4) | `` python312Packages.nanomsg-python: format with nixfmt ``                          |
| [`bd16fcc9`](https://github.com/NixOS/nixpkgs/commit/bd16fcc918d0f77df731a375d2443978131d0b2b) | `` python312Packages.nanomsg-python: refactor ``                                    |
| [`c234e8bb`](https://github.com/NixOS/nixpkgs/commit/c234e8bbcf7696499a5c46ad2216156ea72a4f21) | `` python312Packages.nanotime: format with nixfmt ``                                |
| [`ba3b525b`](https://github.com/NixOS/nixpkgs/commit/ba3b525b28a6533dcde91644cd4415540012fd09) | `` python312Packages.nanotime: refactor ``                                          |
| [`912dd75b`](https://github.com/NixOS/nixpkgs/commit/912dd75be75244e311643da708be49e88d989fed) | `` pre-commit: 3.7.0 -> 3.7.1 ``                                                    |
| [`f89e81ed`](https://github.com/NixOS/nixpkgs/commit/f89e81edcb55053bc56bc9d1be9bc46458c89594) | `` python312Packages.nats-python: format with nixfmt ``                             |
| [`c2715b4f`](https://github.com/NixOS/nixpkgs/commit/c2715b4f942779774ae9a6d791891626aa81918d) | `` python312Packages.nats-python: refactor ``                                       |
| [`4f75fe5b`](https://github.com/NixOS/nixpkgs/commit/4f75fe5b36a547952bf0f9d6f03bce14a17a1b0e) | `` keycloak: 24.0.3 -> 24.0.4 ``                                                    |
| [`94e8c64a`](https://github.com/NixOS/nixpkgs/commit/94e8c64a87888c69d8dd770f640abb7cd327bee5) | `` python312Packages.html2text: format with nixfmt ``                               |
| [`9263c48e`](https://github.com/NixOS/nixpkgs/commit/9263c48e1ba662ecc1953ac1fd093baefaa2ed6a) | `` python312Packages.html2text: refactor ``                                         |
| [`fd6a0bf8`](https://github.com/NixOS/nixpkgs/commit/fd6a0bf895a1ead504ff0cc384104574151b8090) | `` terramate: 0.4.2 -> 0.8.4 ``                                                     |
| [`2a2f741d`](https://github.com/NixOS/nixpkgs/commit/2a2f741d614328a78942440ef3ade904842e375d) | `` python312Packages.hikvision: format with nixfmt ``                               |
| [`714be553`](https://github.com/NixOS/nixpkgs/commit/714be553ac97116d82b5e3a5dc7d5f5f33769e5f) | `` python312Packages.hikvision: refactor ``                                         |
| [`d9a809c2`](https://github.com/NixOS/nixpkgs/commit/d9a809c202be790b69d42c144910db7796b3a501) | `` python312Packages.hjson: format with nixfmt ``                                   |
| [`20589a7b`](https://github.com/NixOS/nixpkgs/commit/20589a7b9935567a4341c620a26fcd41e9f2e50d) | `` python312Packages.hjson: refactor ``                                             |
| [`454a5f23`](https://github.com/NixOS/nixpkgs/commit/454a5f23d61f92265e652e3c263bebc27e48117b) | `` python312Packages.coordinates: format with nixfmt ``                             |
| [`bc3024d4`](https://github.com/NixOS/nixpkgs/commit/bc3024d45426ec12db1a61ce0ed3a7fbf55edbcb) | `` python312Packages.coordinates: refactor ``                                       |
| [`45946fbf`](https://github.com/NixOS/nixpkgs/commit/45946fbf0fa452d874f92095552a1a7888fd6d73) | `` thunderbirdPackages.thunderbird-102: convert to a `throw` (#308820) ``           |
| [`970884ec`](https://github.com/NixOS/nixpkgs/commit/970884ecf14d175b6333d4ab2c3fc8308456658c) | `` python312Packages.tesla-fleet-api: format with nixfmt ``                         |
| [`ff97cbbe`](https://github.com/NixOS/nixpkgs/commit/ff97cbbef989d1bc3f90f2a73a2463367b337920) | `` python311Packages.dask-yarn: fix build for python 3.12 ``                        |
| [`a3e63619`](https://github.com/NixOS/nixpkgs/commit/a3e636191d4fcccf043dfa3e3ec56cb1eb2ccac6) | `` python312Packages.tesla-fleet-api: 0.5.6 -> 0.5.9 ``                             |
| [`e86769d1`](https://github.com/NixOS/nixpkgs/commit/e86769d1246c0f297ec8dc4e4c2188883b33df37) | `` python312Packages.publicsuffixlist: 0.10.0.20240508 -> 0.10.0.20240512 ``        |
| [`4a74c4cf`](https://github.com/NixOS/nixpkgs/commit/4a74c4cf51d701ab11926cf39fc2972d941ecbd1) | `` ip2unix: upstream PR for out of range access ``                                  |
| [`079bb52d`](https://github.com/NixOS/nixpkgs/commit/079bb52d4a3d107e7434054143c8634ee16ddf93) | `` maintainers: add ilya-epifanov ``                                                |
| [`655aa1c8`](https://github.com/NixOS/nixpkgs/commit/655aa1c85ef330ac39844a14de624b1c03350b22) | `` tootik: 0.10.4 -> 0.11.2 ``                                                      |
| [`7eb5beb6`](https://github.com/NixOS/nixpkgs/commit/7eb5beb6e752277e766ce4a8546154f94338178a) | `` sqldef: 0.17.7 -> 0.17.8 ``                                                      |
| [`b1d55c7e`](https://github.com/NixOS/nixpkgs/commit/b1d55c7e32fa1b143b35582375c35cd0d9fa59ad) | `` python312Packages.adext: add changelog to meta ``                                |
| [`22312bf8`](https://github.com/NixOS/nixpkgs/commit/22312bf8f0fc004cd9968c93a428f7c9c51926bb) | `` python312Packages.adext: format with nixfmt ``                                   |
| [`47612dcc`](https://github.com/NixOS/nixpkgs/commit/47612dcc404685ca9cb1dd15cb8401dadb456a1e) | `` python311Packages.adext: refactor ``                                             |
| [`f051260e`](https://github.com/NixOS/nixpkgs/commit/f051260ea0853c18c339dd61e8fe742bdfcf4a40) | `` python312Packages.apprise: format with nixfmt ``                                 |
| [`3b87eaf7`](https://github.com/NixOS/nixpkgs/commit/3b87eaf7bf436f0161c3f2e9cae7b2e27aea77ef) | `` python312Packages.pyinsteon: format with nixfmt ``                               |
| [`e30c6950`](https://github.com/NixOS/nixpkgs/commit/e30c69507d69308be6ea856aaf26edea9cdd8be6) | `` python311Packages.pyinsteon: 1.5.3 -> 1.6.1 ``                                   |
| [`42050e0b`](https://github.com/NixOS/nixpkgs/commit/42050e0b09dee3fb3b6fc0aca20f21730879c040) | `` patch2pr: 0.22.0 -> 0.24.0 ``                                                    |
| [`8f339b27`](https://github.com/NixOS/nixpkgs/commit/8f339b27ddf1eece996e666d161baf3ea4a5c8cc) | `` eduke32: convert bmp -> png for gdk-pixbuf-csource ``                            |
| [`efbd3756`](https://github.com/NixOS/nixpkgs/commit/efbd375613d8c75bc1a897508975d16da3dccc79) | `` kubectl-explore: 0.8.3 -> 0.9.3 ``                                               |
| [`1d2dff45`](https://github.com/NixOS/nixpkgs/commit/1d2dff45d3f3b8820f0f48d162813c128bc9e4df) | `` php: fix build on darwin (the `iconv` extension) ``                              |
| [`e7848539`](https://github.com/NixOS/nixpkgs/commit/e7848539bb92f96b59f923dea77cf73ddac36a38) | `` files-cli: 2.13.27 -> 2.13.41 ``                                                 |
| [`95c0bbe1`](https://github.com/NixOS/nixpkgs/commit/95c0bbe10676506e809b0738a4f649d6e176b3a0) | `` python311Packages.pynmeagps: 1.0.35 -> 1.0.36 ``                                 |
| [`87664662`](https://github.com/NixOS/nixpkgs/commit/8766466245141a3fa314200f5cef4afb8abe41d8) | `` troubadix: 24.4.1 -> 24.5.1 ``                                                   |
| [`a01cf4d9`](https://github.com/NixOS/nixpkgs/commit/a01cf4d9891bb84d8e1eed4197183496da4d7a19) | `` scc: move to by-name ``                                                          |
| [`e93b4b50`](https://github.com/NixOS/nixpkgs/commit/e93b4b50be35cf6944cb564f85bb3d2f5d11d1bd) | `` kora-icon-theme: 1.6.0 -> 1.6.1 ``                                               |
| [`41a56694`](https://github.com/NixOS/nixpkgs/commit/41a56694251e3e08d5ed5239e14b0495f2fdce8e) | `` vbam: Fix gsettings problems. ``                                                 |
| [`7bd75693`](https://github.com/NixOS/nixpkgs/commit/7bd75693159735d15527720a03c69a3907f09ce0) | `` yq-go: 4.43.1 -> 4.44.1 ``                                                       |
| [`92571807`](https://github.com/NixOS/nixpkgs/commit/925718078d575bca93609406995b885897ad43e0) | `` feishin: 0.6.1 → 0.7.1 ``                                                        |
| [`0bc4e80c`](https://github.com/NixOS/nixpkgs/commit/0bc4e80cd1ed67252bffbb3953869e2328550ec9) | `` opensaml-cpp: fix darwin builds ``                                               |
| [`2cc214b4`](https://github.com/NixOS/nixpkgs/commit/2cc214b4c3e8e116e6af6f40735e99a505b653be) | `` freebsd: 13.1.0 -> 14.0.0 ``                                                     |
| [`06b05d22`](https://github.com/NixOS/nixpkgs/commit/06b05d2289599dd434b6991fa25685ce5cb9a136) | `` freebsd: Cleanup, get ready to support version 14 ``                             |
| [`4bedab9c`](https://github.com/NixOS/nixpkgs/commit/4bedab9cf86144d6d3c2d2efea12b068daa7831e) | `` mcfly: 0.8.4 -> 0.8.5 ``                                                         |
| [`c9439814`](https://github.com/NixOS/nixpkgs/commit/c943981470f48f72300a1617f856aa06398d0ade) | `` jmusicbot: 0.4.0 -> 0.4.1 ``                                                     |
| [`3a1ae6f5`](https://github.com/NixOS/nixpkgs/commit/3a1ae6f52ceb53a0c2397816eeb94b2212346b06) | `` go-minimock: 3.3.7 -> 3.3.8 ``                                                   |
| [`11c39082`](https://github.com/NixOS/nixpkgs/commit/11c39082ecbe72fd5defe6e0b5d15a105ac4ede6) | `` git-instafix: 0.2.2 -> 0.2.3 ``                                                  |
| [`ad5e5008`](https://github.com/NixOS/nixpkgs/commit/ad5e5008712b3344d4b89e1b91b24a470ab45dcd) | `` dorion: 4.2.0 -> 4.2.1 ``                                                        |
| [`89aa9786`](https://github.com/NixOS/nixpkgs/commit/89aa9786127886d217367bafd62dd364b6ff1a70) | `` python311Packages.apprise: 1.7.6 -> 1.8.0 ``                                     |
| [`8e8de999`](https://github.com/NixOS/nixpkgs/commit/8e8de9998405cc21845dba9eed809c4b0d3fcde8) | `` brev-cli: 0.6.279 -> 0.6.284 ``                                                  |
| [`12c7be35`](https://github.com/NixOS/nixpkgs/commit/12c7be354e6cb71b5ceedfd7ab8f8eb813a17035) | `` octosql: 0.12.2 -> 0.13.0 ``                                                     |
| [`a77e56cd`](https://github.com/NixOS/nixpkgs/commit/a77e56cdc7cdad2fbca9e8f69f0264ad42589f96) | `` python311Packages.sacn: 1.9.0 -> 1.9.1 ``                                        |
| [`11d25281`](https://github.com/NixOS/nixpkgs/commit/11d25281e4186a62cb696f577e5589cb859d5f18) | `` python312Packages.albumentations: fix dependencies, fix tests ``                 |
| [`958181e1`](https://github.com/NixOS/nixpkgs/commit/958181e1603bc03b69061aff91d4b01ef86c03d6) | `` python311Packages.mdtraj: disable flaky tests ``                                 |
| [`64877c3e`](https://github.com/NixOS/nixpkgs/commit/64877c3e7930e3b527033a990a6daeaaeeba278c) | `` python311Packages.pipdeptree: 2.19.1 -> 2.20.0 ``                                |
| [`cce575cf`](https://github.com/NixOS/nixpkgs/commit/cce575cf6b38ee88552ad3b4cc608363d853c9ab) | `` python312Packages.setuptools-gettext: 0.1.11 -> 0.1.14 ``                        |
| [`ffb210ba`](https://github.com/NixOS/nixpkgs/commit/ffb210bab223c381ee519b3e02c4d27b49385428) | `` irpf: 2024-1.0 -> 2024-1.1 ``                                                    |
| [`6664a7a2`](https://github.com/NixOS/nixpkgs/commit/6664a7a23944c49e57bef2bfd00ddf2f992d8466) | `` vte: reduce warning volume ``                                                    |
| [`a1e9afa5`](https://github.com/NixOS/nixpkgs/commit/a1e9afa59b86646e360c9d8a3984b051323f6136) | `` flarectl: 0.94.0 -> 0.95.0 ``                                                    |
| [`b5a6f6e3`](https://github.com/NixOS/nixpkgs/commit/b5a6f6e3d2d54bec905f69b7cffb13e9ca5a259f) | `` python311Packages.ihm: 1.0 -> 1.1 ``                                             |
| [`93b1b348`](https://github.com/NixOS/nixpkgs/commit/93b1b348e768d48afbb6584484154609714c1d9e) | `` python311Packages.adext: 0.4.2 -> 0.4.3 ``                                       |
| [`272cbd35`](https://github.com/NixOS/nixpkgs/commit/272cbd358faf61bb01360919a6361dd9c135e6da) | `` vscode-extensions.myriad-dreamin.tinymist: 0.11.7 -> 0.11.8 ``                   |
| [`20aa886d`](https://github.com/NixOS/nixpkgs/commit/20aa886dbe27acfe628efb3982d5e6a3030014e1) | `` tinymist: 0.11.6 -> 0.11.8 ``                                                    |
| [`217662c0`](https://github.com/NixOS/nixpkgs/commit/217662c047710ea14d12317cebdad243808b2991) | `` python311Packages.cloudflare: 2.19.4 -> 2.20.0 ``                                |
| [`be87d02b`](https://github.com/NixOS/nixpkgs/commit/be87d02b005f703e2b009f93ff6b1b5c7f9d4efd) | `` crunchy-cli: 3.5.2 -> 3.6.1 ``                                                   |
| [`681f9754`](https://github.com/NixOS/nixpkgs/commit/681f9754fe08d760c984b349e676a863bad8a82c) | `` waypaper: 2.1 -> 2.1.2 ``                                                        |
| [`7909e0f7`](https://github.com/NixOS/nixpkgs/commit/7909e0f7d63ddb627867f1198ffbb09f2fe31c9f) | `` nixos/pixiecore: fix apiServer example ``                                        |
| [`3388179c`](https://github.com/NixOS/nixpkgs/commit/3388179c48fa673ae466f12d15cd7864b8e7cd3c) | `` lix: init at 2.90-beta.1 ``                                                      |
| [`5c76fc5b`](https://github.com/NixOS/nixpkgs/commit/5c76fc5b30c1e87f3f0600b92126931ae9b5d72a) | `` forbidden: 10.8 -> 10.9 ``                                                       |