### PR TITLE
chore(flake/nixpkgs): `3eaeaeb6` -> `5710852b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716293225,
-        "narHash": "sha256-pU9ViBVE3XYb70xZx+jK6SEVphvt7xMTbm6yDIF4xPs=",
+        "lastModified": 1716330097,
+        "narHash": "sha256-8BO3B7e3BiyIDsaKA0tY8O88rClYRTjvAp66y+VBUeU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3eaeaeb6b1e08a016380c279f8846e0bd8808916",
+        "rev": "5710852ba686cc1fd0d3b8e22b3117d43ba374c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`bff37b64`](https://github.com/NixOS/nixpkgs/commit/bff37b6408d2488e603d5d62a87f3a5a381f0e0c) | `` kdePackages.bluedevil: work around broken upstream tarball ``              |
| [`4fe704b1`](https://github.com/NixOS/nixpkgs/commit/4fe704b10f61f51ae063cea32e07d098b86dc2b9) | `` kdePackages.krfb: fix build ``                                             |
| [`fe783b3d`](https://github.com/NixOS/nixpkgs/commit/fe783b3d8c94f3da5b789e9b03cab0a6b28f65fb) | `` python312Packages.lacuscore: format with nixfmt ``                         |
| [`1e2f3766`](https://github.com/NixOS/nixpkgs/commit/1e2f37664bc13e2da2365826d131a81ffb6de9a4) | `` python312Packages.lacuscore: refactor ``                                   |
| [`b9e9ca26`](https://github.com/NixOS/nixpkgs/commit/b9e9ca26c49c9dd968bf30bffdc72349ff5545cf) | `` python312Packages.lacuscore: 1.9.3 -> 1.9.4 ``                             |
| [`aaac4a9e`](https://github.com/NixOS/nixpkgs/commit/aaac4a9ea8ebb3852b4eeed6ad96e9078ef6050b) | `` python312Packages.playwrightcapture: 1.24.9 -> 1.24.10 ``                  |
| [`183f42dc`](https://github.com/NixOS/nixpkgs/commit/183f42dc67f2380b18ed5c88a245eec69355800a) | `` python312Packages.fastcore: 1.5.35 -> 1.5.38 ``                            |
| [`cfbbf54f`](https://github.com/NixOS/nixpkgs/commit/cfbbf54f8943c074a15cea682e1ac8751b80fe87) | `` python312Packages.lmtpd: format with nixfmt ``                             |
| [`bbe77ffd`](https://github.com/NixOS/nixpkgs/commit/bbe77ffdfaedc10a95d0b1bc704d20cefdf7a5fc) | `` python312Packages.lmtpd: disable on Python 3.12 ``                         |
| [`90916525`](https://github.com/NixOS/nixpkgs/commit/90916525a65e072d8e0f2db33f316827309ebcb0) | `` nixos/navidrome: set empty settings default ``                             |
| [`f953913c`](https://github.com/NixOS/nixpkgs/commit/f953913c65d89ba06997c3a7dac090914fb70c10) | `` nixos/gnupg: remove dead code ``                                           |
| [`af4a3914`](https://github.com/NixOS/nixpkgs/commit/af4a3914244acd72bb12530e4907e81bc2fb2499) | `` nixos/vector: Added DNSTAP testcase ``                                     |
| [`25995c9f`](https://github.com/NixOS/nixpkgs/commit/25995c9ff8c079fb28e11a34ada6c4164ae9fff2) | `` zigbee2mqtt: make systemd support optional ``                              |
| [`8dc825ca`](https://github.com/NixOS/nixpkgs/commit/8dc825ca3681a602f6414134cda35cc513e2443c) | `` nixos/vector: Added nginx→clickhouse test case ``                          |
| [`1b27c588`](https://github.com/NixOS/nixpkgs/commit/1b27c58827309f3f75cb659d6982f1836740723b) | `` nixos/vector: Added testcase for verifying API endpoint ``                 |
| [`f8d18977`](https://github.com/NixOS/nixpkgs/commit/f8d18977df6eda5e2c4a49522b1762d75ba3db93) | `` kdePackages.plasma6: 6.0.4 -> 6.0.5 ``                                     |
| [`158e5353`](https://github.com/NixOS/nixpkgs/commit/158e53535300c8307cb866560f7dc29d29d9e88f) | `` libreoffice: fix build, big expression cleanup ``                          |
| [`87cb2655`](https://github.com/NixOS/nixpkgs/commit/87cb26558857e505b15549e854f7bc63575ee1f9) | `` nixos/vector: Moved existing test to subdirectory ``                       |
| [`f70f8f7c`](https://github.com/NixOS/nixpkgs/commit/f70f8f7c5507484770d31d39f919d1b479b2244a) | `` libreoffice-still: 7.5.9.2 -> 7.6.7.2 ``                                   |
| [`4a4e7449`](https://github.com/NixOS/nixpkgs/commit/4a4e74498ee8043157231d251065d47ea6a16915) | `` libreoffice-fresh: 7.6.4.1 -> 24.2.3.2 ``                                  |
| [`da4abb90`](https://github.com/NixOS/nixpkgs/commit/da4abb904acc2e90be93fee7d08c8fe5c7e66606) | `` libetonyek: init at 0.1.10 ``                                              |
| [`b1f998f5`](https://github.com/NixOS/nixpkgs/commit/b1f998f5c7704ec0f88586d4f77a012ee3c9c444) | `` libertine-g: init at 2012-01-16 ``                                         |
| [`c387b633`](https://github.com/NixOS/nixpkgs/commit/c387b6338f332a781bf0b9ab622b5bad4d4db0f4) | `` libepubgen: init at 0.1.1 ``                                               |
| [`91174e6a`](https://github.com/NixOS/nixpkgs/commit/91174e6a2cc65438a17f9ddfb2c6075a4d0cf233) | `` liborcus: init at 0.19.2 ``                                                |
| [`03d505df`](https://github.com/NixOS/nixpkgs/commit/03d505df0c3c7ea719a4c1586bc5be358f5607f9) | `` libixion: init at 0.19.0 ``                                                |
| [`13678d2d`](https://github.com/NixOS/nixpkgs/commit/13678d2dd23bfc229c07572b9f1b67b2a2e9eced) | `` libreoffice-bin: 7.6.4 -> 7.6.7 ``                                         |
| [`8e8d3f96`](https://github.com/NixOS/nixpkgs/commit/8e8d3f961e648616ae372fa9e12af41f9100ca01) | `` werf: 2.0.4 -> 2.1.0 ``                                                    |
| [`d62141d0`](https://github.com/NixOS/nixpkgs/commit/d62141d024493276446fed8faf92dcc29d51a049) | `` pietrasanta-traceroute: init at `0.0.5-unstable-2023-11-28` (#313400) ``   |
| [`c2bdcca6`](https://github.com/NixOS/nixpkgs/commit/c2bdcca62e72571e2b4956b8ca60a00f3485901c) | `` vscode-extensions.shd101wyy.markdown-preview-enhanced: 0.8.12 -> 0.8.13 `` |
| [`3df8dcc4`](https://github.com/NixOS/nixpkgs/commit/3df8dcc487f2838e62a040e5abf9bbd9ee823720) | `` telegraf: 1.30.2 -> 1.30.3 ``                                              |
| [`6397ca49`](https://github.com/NixOS/nixpkgs/commit/6397ca49b73d6593397716ebbb3e6dcb9fa439fb) | `` kaufkauflist: 3.3.0 → 4.0.0 (#310337) ``                                   |
| [`1f069c65`](https://github.com/NixOS/nixpkgs/commit/1f069c65c2838f46c3ccb301ca7399209a6849b2) | `` polkadot: 1.11.0 -> 1.12.0 ``                                              |
| [`f26e8f43`](https://github.com/NixOS/nixpkgs/commit/f26e8f439c4a335989a00542b479fecc223ff4d0) | `` llama-cpp: 2901 -> 2953 ``                                                 |
| [`4212454a`](https://github.com/NixOS/nixpkgs/commit/4212454a63fe8dc092f6901dd95b9809ea7354f4) | `` alephone-marathon: disable nixpkgs-update ``                               |
| [`ddd0c8f0`](https://github.com/NixOS/nixpkgs/commit/ddd0c8f0e140af21a779ffb818e2657f1aae34c0) | `` liblapin: init at 0-unstable-2024-05-20 ``                                 |
| [`dfcccd13`](https://github.com/NixOS/nixpkgs/commit/dfcccd136664dacabb84363536cdf12d705bcc7e) | `` extism-cli: 1.3.0 -> 1.4.0 ``                                              |
| [`84d5f56a`](https://github.com/NixOS/nixpkgs/commit/84d5f56ad73bde560c45b12b0d7a2cf3b8fbb594) | `` linuxKernel.kernels.linux_lqx: 6.8.6-lqx2 -> 6.8.10-lqx1 ``                |
| [`5516382a`](https://github.com/NixOS/nixpkgs/commit/5516382a648754f67b41215ad55656790fbcf2ab) | `` linuxKernel.kernels.linux_zen: 6.8.6-zen1 -> 6.9.1-zen1 ``                 |
| [`1f1a9bb1`](https://github.com/NixOS/nixpkgs/commit/1f1a9bb15d60905d1d52f49f5e153e6279124e26) | `` netscanner: 0.4.5 -> 0.5.1 ``                                              |
| [`f6a9c1fe`](https://github.com/NixOS/nixpkgs/commit/f6a9c1fede7dd66ce8bacf928ade552a93183ca2) | `` python312Packages.pycookiecheat: format with nixfmt ``                     |
| [`22c9a528`](https://github.com/NixOS/nixpkgs/commit/22c9a528315dad96f7dbc9bb4757503fe6b01996) | `` python312Packages.pycookiecheat: refactor ``                               |
| [`7c348f0a`](https://github.com/NixOS/nixpkgs/commit/7c348f0ab6647b33996810747cf665413b351460) | `` qt6.qtmqtt: 6.7.0 -> 6.7.1 ``                                              |
| [`486219cc`](https://github.com/NixOS/nixpkgs/commit/486219cc137b90a97b1607691ff9a04b694ba609) | `` python312Packages.pycookiecheat: 0.6.0 -> 0.7.0 ``                         |
| [`6aea91e1`](https://github.com/NixOS/nixpkgs/commit/6aea91e153aae4c2e9bb59068a9c20caef56bab1) | `` python312Packages.lnkparse3: refactor ``                                   |
| [`9f9610c3`](https://github.com/NixOS/nixpkgs/commit/9f9610c3140b4a0321451f9fe6bf3989137f537f) | `` python312Packages.lnkparse3: format with nixfmt ``                         |
| [`ccf57ee1`](https://github.com/NixOS/nixpkgs/commit/ccf57ee1ec618e8ff15b53d15acce59167dcded9) | `` python312Packages.lnkparse3: 1.4.0 -> 1.5.0 ``                             |
| [`a1c37a6a`](https://github.com/NixOS/nixpkgs/commit/a1c37a6a58d6b62c64c820b54d75bc54f47dc30f) | `` bpftrace: 0.20.3 -> 0.20.4 ``                                              |
| [`ddc323ab`](https://github.com/NixOS/nixpkgs/commit/ddc323abffac8c95121bfca839fce3a4f96532ec) | `` gamescope: 3.14.15 -> 3.14.16 ``                                           |
| [`a1f4cd31`](https://github.com/NixOS/nixpkgs/commit/a1f4cd3113870138d1a9632580b1ffbb90255e00) | `` python312Packages.crownstone-cloud: format with nixfmt ``                  |
| [`baeeded2`](https://github.com/NixOS/nixpkgs/commit/baeeded2c6de36a9d47615455d583ffb3eeda1ef) | `` python312Packages.crownstone-cloud: refactor ``                            |
| [`a854d724`](https://github.com/NixOS/nixpkgs/commit/a854d724c4618b27872171e62db17353769f1ee7) | `` python312Packages.crownstone-cloud: 1.4.9 -> 1.4.11 ``                     |
| [`f0f3609d`](https://github.com/NixOS/nixpkgs/commit/f0f3609dd58796ec100b8d2f0228ddb98a5c7c29) | `` python312Packages.crownstone-sse: format with nixfmt ``                    |
| [`ee6abbad`](https://github.com/NixOS/nixpkgs/commit/ee6abbad3bab49f7adcc00fe57ae07156d3cfe3f) | `` python312Packages.crownstone-sse: refactor ``                              |
| [`e971750c`](https://github.com/NixOS/nixpkgs/commit/e971750c2466440366730f1330ae321278f27d85) | `` python312Packages.crownstone-sse: 2.0.4 -> 2.0.5 ``                        |
| [`be774f01`](https://github.com/NixOS/nixpkgs/commit/be774f013b27225880d8e60796b1bd00b8a87dd3) | `` obs-studio-plugins.advanced-scene-switcher: 1.26.1 -> 1.26.2 ``            |
| [`567125c6`](https://github.com/NixOS/nixpkgs/commit/567125c65ad1b38ace66f0c4d1434a96ade039d5) | `` jikespg: fixed darwin build ``                                             |
| [`3ff593a5`](https://github.com/NixOS/nixpkgs/commit/3ff593a54d58295b5940207dea2fb4b6923928a3) | `` raycast: 1.74.0 -> 1.74.1 ``                                               |
| [`47da0aee`](https://github.com/NixOS/nixpkgs/commit/47da0aee5616a063015f10ea593688646f2377e4) | `` qt6: 6.7.0 -> 6.7.1 ``                                                     |
| [`317e4083`](https://github.com/NixOS/nixpkgs/commit/317e40837c114dff6efd8f13ad182764da1d994c) | `` python312Packages.walrus: fix python 3.12 build ``                         |
| [`c23df6a7`](https://github.com/NixOS/nixpkgs/commit/c23df6a70c9b16d67c3dc0b0d5c42e050d404bdf) | `` python311Packages.rokuecp: 0.19.3 -> 0.19.4 ``                             |
| [`0234bac7`](https://github.com/NixOS/nixpkgs/commit/0234bac73cf53bee97ccdddef71748be10a88479) | `` docker_26: 26.0.0 -> 26.1.3 ``                                             |
| [`3e14c44e`](https://github.com/NixOS/nixpkgs/commit/3e14c44e21ee1c1d41888e7c39acb834be5e7b23) | `` nixos/simplesamlphp: init module ``                                        |
| [`a066405c`](https://github.com/NixOS/nixpkgs/commit/a066405ce11ccc41e8343265257ba684fb6d6b65) | `` python312Packages.hyrule: format with nixfmt ``                            |
| [`e7023684`](https://github.com/NixOS/nixpkgs/commit/e70236849739e24c983c5074f33ef682fd0c2d8c) | `` python312Packages.hyrule: refactor ``                                      |
| [`d3d1bdc6`](https://github.com/NixOS/nixpkgs/commit/d3d1bdc66ca0323fb80a760e7778e4521a92d366) | `` python312Packages.hyrule: 0.5.0 -> 0.6.0 ``                                |
| [`2b2ccb78`](https://github.com/NixOS/nixpkgs/commit/2b2ccb78165b29d79765d7d69d7dfb22f177e81f) | `` python312Packages.hy:format with nixfmt ``                                 |
| [`778e6403`](https://github.com/NixOS/nixpkgs/commit/778e640394681fe7c9b746308ca62de7a5aa30cc) | `` python312Packages.hy: remove myself from maintainers ``                    |
| [`276e86d8`](https://github.com/NixOS/nixpkgs/commit/276e86d8ab624a75b86f0f78ae0ee3727e80e700) | `` python311Packages.hy: refactor ``                                          |
| [`9d5ff613`](https://github.com/NixOS/nixpkgs/commit/9d5ff613e55f231a122982d033624c6c0f178f51) | `` perlPackages: fix wine-staging build on i686 ``                            |
| [`136720f1`](https://github.com/NixOS/nixpkgs/commit/136720f1eae931e6d29bcd97931145d2e0b08bb1) | `` vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.21.1 -> 0.21.2 ``         |
| [`0bc0302b`](https://github.com/NixOS/nixpkgs/commit/0bc0302b1889f53a5ee1979bcbf90209c09a6ba2) | `` simplesamlphp: init at 1.19.7 ``                                           |
| [`723dfb27`](https://github.com/NixOS/nixpkgs/commit/723dfb272774b45adbbff59431eef87c4f9b0194) | `` rawtherapee: switch to patch version merged upstream ``                    |
| [`dffc52ce`](https://github.com/NixOS/nixpkgs/commit/dffc52ce3f122be58777b8fa9ce24a77ff5b2c78) | `` libmodulemd: fix build after glib update from PR #309952 ``                |
| [`0ba73537`](https://github.com/NixOS/nixpkgs/commit/0ba73537d7e9a7afaa32b4c9ba9c90402a535cdd) | `` rsbkb: 1.3 -> 1.4 ``                                                       |
| [`846c76d0`](https://github.com/NixOS/nixpkgs/commit/846c76d05c47da7ac69d90af8ca065fe83cc454a) | `` icewm: 3.4.7 -> 3.5.0 ``                                                   |
| [`7dc4a007`](https://github.com/NixOS/nixpkgs/commit/7dc4a007a1d0080e312c64cdaf2f9e0a2469e4fb) | `` clickhouse-backup: 2.5.8 -> 2.5.9 ``                                       |
| [`5df9a95b`](https://github.com/NixOS/nixpkgs/commit/5df9a95bc78306d521d2701d7933c4b1bf802ad4) | `` agola: 0.9.1 -> 0.9.2 ``                                                   |
| [`00585528`](https://github.com/NixOS/nixpkgs/commit/00585528916b9a469f0f8835e8006b6643b9630d) | `` pkgs/applications: remove uneeded fetchpatch arguments ``                  |
| [`532cecac`](https://github.com/NixOS/nixpkgs/commit/532cecace798b1265bd74d9160e54e7e99bd9569) | `` python311Packages.hy: 0.28.0 -> 0.29.0 ``                                  |
| [`d4879149`](https://github.com/NixOS/nixpkgs/commit/d487914932a906c67481cbb9c83f16122eed146e) | `` python311Packages.biopandas: 0.4.1 -> 0.5.0 ``                             |
| [`6c8bca05`](https://github.com/NixOS/nixpkgs/commit/6c8bca0541dc4f1c6201d62bf4d75cb4592ad409) | `` python311Packages.biopandas: format with nixfmt ``                         |
| [`98c84e67`](https://github.com/NixOS/nixpkgs/commit/98c84e67e47283304739f8a53bd3b18bc024dc84) | `` nixos/lomiri: Add power indicator ``                                       |
| [`6539b60f`](https://github.com/NixOS/nixpkgs/commit/6539b60f0b289add88d125ec45d748c4241c79b8) | `` ayatana-indicator-power: init at 24.1.0 ``                                 |
| [`6d3992f1`](https://github.com/NixOS/nixpkgs/commit/6d3992f17bbc97fffca66370c8c5312f7e369bd4) | `` miriway: 0-unstable-2024-04-30 -> 0-unstable-2024-05-17 ``                 |
| [`29268b92`](https://github.com/NixOS/nixpkgs/commit/29268b929462c515892a7cde9f5e6619a03682c9) | `` kde-rounded-corners: add devusb to maintainers ``                          |
| [`dde154d5`](https://github.com/NixOS/nixpkgs/commit/dde154d5a4c3e4b90097aabdc981c90a37d81da4) | `` kde-rounded-corners: switch to kdePackages ``                              |
| [`79081fda`](https://github.com/NixOS/nixpkgs/commit/79081fda5ea6ae264134c61a9033c5c43b842da3) | `` linux/hardened/patches/6.9: init at 6.9.1-hardened1 ``                     |
| [`2da64127`](https://github.com/NixOS/nixpkgs/commit/2da641279900c34611307efa01391a849dcfe61d) | `` linux/hardened/patches/6.8: 6.8.9-hardened1 -> 6.8.10-hardened1 ``         |
| [`f6347236`](https://github.com/NixOS/nixpkgs/commit/f63472362f4b4a9896947541b251f9e2eb120afe) | `` linux/hardened/patches/6.6: 6.6.30-hardened1 -> 6.6.31-hardened1 ``        |
| [`6b5fc5d7`](https://github.com/NixOS/nixpkgs/commit/6b5fc5d730633d8fdbadf145ed6e9886d67f427d) | `` linux/hardened/patches/6.1: 6.1.90-hardened1 -> 6.1.91-hardened1 ``        |
| [`194cc4a7`](https://github.com/NixOS/nixpkgs/commit/194cc4a79e99166801f8e66f36149143b6c8612a) | `` linux/hardened/patches/5.4: 5.4.275-hardened1 -> 5.4.276-hardened1 ``      |
| [`2d5c7544`](https://github.com/NixOS/nixpkgs/commit/2d5c7544689cb2a4db57dad2d18da07a854dd9ff) | `` linux/hardened/patches/5.15: 5.15.158-hardened1 -> 5.15.159-hardened1 ``   |
| [`bed5bf9e`](https://github.com/NixOS/nixpkgs/commit/bed5bf9e08abbd5bda596d3b58a8af0a178d19fc) | `` linux/hardened/patches/5.10: 5.10.216-hardened1 -> 5.10.217-hardened1 ``   |
| [`f205d593`](https://github.com/NixOS/nixpkgs/commit/f205d59323469fe761403b9746718ffe1aecae15) | `` linux/hardened/patches/4.19: 4.19.313-hardened1 -> 4.19.314-hardened1 ``   |
| [`1e3397fd`](https://github.com/NixOS/nixpkgs/commit/1e3397fd4b28f85909f7d861db9996c5eccf82a6) | `` innoextract: fixed darwin build ``                                         |
| [`215eb32e`](https://github.com/NixOS/nixpkgs/commit/215eb32ecbcbb15cecf0e2a995b7381d6be0b756) | `` forgejo: remove no longer needed preBuild phase (noop) ``                  |
| [`3be24f88`](https://github.com/NixOS/nixpkgs/commit/3be24f885b0996eee749c6711b2cbb77379c2cb7) | `` windmill: 1.246.15 -> 1.333.2 ``                                           |
| [`b061be6a`](https://github.com/NixOS/nixpkgs/commit/b061be6a61ccfbf0db5173e413ebf99700d9f2a4) | `` wasm-tools: 1.207.0 -> 1.208.1 ``                                          |
| [`a78af08f`](https://github.com/NixOS/nixpkgs/commit/a78af08f5e9806eef5cd135ff9ccc8685ea7ffdb) | `` unciv: 4.11.12 -> 4.11.13 ``                                               |
| [`ffc73a59`](https://github.com/NixOS/nixpkgs/commit/ffc73a590a711f66f713df3fefe06648db844a07) | `` bpftune: unstable-2023-12-20 -> 0-unstable-2024-05-17 ``                   |
| [`614986f6`](https://github.com/NixOS/nixpkgs/commit/614986f6065e06c0c859a53a1988d99359486fe1) | `` python311Packages.pyperf: 2.6.3 -> 2.7.0 ``                                |
| [`c88cecc3`](https://github.com/NixOS/nixpkgs/commit/c88cecc37acc32ea0982da9f286290b076d47c70) | `` blockbench: fix darwin build ``                                            |
| [`b36536b8`](https://github.com/NixOS/nixpkgs/commit/b36536b83a22396ae61b4d8008a5b519fc4e1858) | `` mcuboot-imgtool: apply nixfmt-rfc-style ``                                 |
| [`8c6e3d91`](https://github.com/NixOS/nixpkgs/commit/8c6e3d917538552b94ca5e55af8f513e1b657702) | `` mcuboot-imgtool: 2.0.0 -> 2.1.0 ``                                         |
| [`c1017f21`](https://github.com/NixOS/nixpkgs/commit/c1017f21b7d9549bea191b2cadfe24caa7de3c91) | `` linkerd_edge: 24.5.2 -> 24.5.3 ``                                          |
| [`498dd425`](https://github.com/NixOS/nixpkgs/commit/498dd425477a6b40131012f9143a5f9a9f2cec85) | `` tenv: 1.11.0 -> 1.11.2 ``                                                  |
| [`3132085f`](https://github.com/NixOS/nixpkgs/commit/3132085f93efa2a0f3e4b817bce030f4bda3aa17) | `` granted: 0.26.0 -> 0.26.2 ``                                               |
| [`a136b455`](https://github.com/NixOS/nixpkgs/commit/a136b4557783a973427cb58fc02039541fc16e76) | `` dotnet-outdated: 4.6.2 -> 4.6.4 ``                                         |
| [`c83d0124`](https://github.com/NixOS/nixpkgs/commit/c83d01249c5b9b8cf8e7f316e6fc81c10c336da9) | `` trivy: 0.51.1 -> 0.51.2 ``                                                 |
| [`9f43e396`](https://github.com/NixOS/nixpkgs/commit/9f43e396ddf387fe8b092d8e1ffe73008d7a579e) | `` python311Packages.cufflinks: refactor and drop nose ``                     |
| [`dbfa5b31`](https://github.com/NixOS/nixpkgs/commit/dbfa5b3135c2f229104f5a7383b7afbc85c67384) | `` python311Packages.cufflinks: format with nixfmt ``                         |
| [`ac9dc286`](https://github.com/NixOS/nixpkgs/commit/ac9dc2867f88e0440c7c7e42d6ec3f86ed23ec7d) | `` python312Packages.lmxf: format with nixfmt ``                              |
| [`9211484e`](https://github.com/NixOS/nixpkgs/commit/9211484ec35e956b8ecb8bfcfbf2534525db478c) | `` python312Packages.nomadnet: format with nixfmt ``                          |
| [`684d72bf`](https://github.com/NixOS/nixpkgs/commit/684d72bf1a5a9816acc918cd7408680bf82755ee) | `` python312Packages.nomadnet: refactor ``                                    |
| [`66146486`](https://github.com/NixOS/nixpkgs/commit/6614648648b0a7c1a254ac7455e2751bb57e6274) | `` python312Packages.nomadnet: 0.4.8 -> 0.4.9 ``                              |
| [`2f31ae59`](https://github.com/NixOS/nixpkgs/commit/2f31ae59e735111abd8c935d82256031e30c98af) | `` python312Packages.rns: 0.7.4 -> 0.7.5 ``                                   |
| [`40168996`](https://github.com/NixOS/nixpkgs/commit/401689964bc0be322aa098746e2abfeafab08c1d) | `` prismlauncher: replace mesa-demos with glxinfo ``                          |
| [`872ed3c8`](https://github.com/NixOS/nixpkgs/commit/872ed3c823667dda7d95677690e7ce9f0d6e82fe) | `` circt: 1.74.0 -> 1.75.0 ``                                                 |
| [`89284c21`](https://github.com/NixOS/nixpkgs/commit/89284c211189ef8590f9d82f7b790419e45b8908) | `` python311Packages.litellm: 1.37.9 -> 1.37.16 ``                            |
| [`45087e16`](https://github.com/NixOS/nixpkgs/commit/45087e1666ea066a241f975aac3e9bf104c40c32) | `` apx: install shell completions ``                                          |
| [`15d8d27b`](https://github.com/NixOS/nixpkgs/commit/15d8d27bd66a336e2a26537448d87cfe2d025b7a) | `` util-linux: also downgrade static builds already ``                        |
| [`fa8ec670`](https://github.com/NixOS/nixpkgs/commit/fa8ec6702a3ee117c98d5519b6b054b0f75c6e9b) | `` util-linux: 2.40.1 -> 2.39.4 (except 64-bit linux for now) ``              |
| [`cdd1aaa8`](https://github.com/NixOS/nixpkgs/commit/cdd1aaa86fa3205b86f0c6c746c8884ba783d4b2) | `` klipper: 0.12.0-unstable-2024-05-14 -> 0.12.0-unstable-2024-05-16 ``       |
| [`b25c0be8`](https://github.com/NixOS/nixpkgs/commit/b25c0be880c2093448d3efd82ea06e67d4a48773) | `` ventoy-full: 1.0.97 -> 1.0.98 ``                                           |
| [`ae709479`](https://github.com/NixOS/nixpkgs/commit/ae7094798d53ee0923ead8d87861e8e77ab0471d) | `` tp-auto-kbbl: use sri hash ``                                              |
| [`42420dbc`](https://github.com/NixOS/nixpkgs/commit/42420dbc060d4c0cf0c2979bf8ba7400336ed9ee) | `` golangci-lint: replace inactive maintainers with myself ``                 |
| [`3b7d9fa9`](https://github.com/NixOS/nixpkgs/commit/3b7d9fa95d8170796cac2aa47dfaaff9fc75a587) | `` golangci-lint: 1.58.1 -> 1.58.2 ``                                         |
| [`a35fac79`](https://github.com/NixOS/nixpkgs/commit/a35fac798e9965ed11ac2a41348f1af5ae839094) | `` apx: 2.4.0 -> 2.4.2 ``                                                     |
| [`0cccca49`](https://github.com/NixOS/nixpkgs/commit/0cccca4926ffecdf2a6a8b9009b8e4b1055d7175) | `` kf5: 5.115 -> 5.116 ``                                                     |
| [`75d0c401`](https://github.com/NixOS/nixpkgs/commit/75d0c401baaf3670a2e1f0cd42a75f7f40d72e52) | `` librewolf-unwrapped: 125.0.3-1 -> 126.0-1 ``                               |
| [`da7ae1ba`](https://github.com/NixOS/nixpkgs/commit/da7ae1baf8102e2f266bfce03230fe7b85604a6a) | `` gvisor: fix ldconfig path ``                                               |
| [`1e2db6c5`](https://github.com/NixOS/nixpkgs/commit/1e2db6c5d8ea44b3ff8925418d24aaa404c8107e) | `` icomoon-feather: init at 0-unstable-2024-05-12 ``                          |
| [`0d2c6642`](https://github.com/NixOS/nixpkgs/commit/0d2c66423820f17a0e3dcc6b8331b4b4e0efbd61) | `` navidrome: 0.52.0 -> 0.52.5 ``                                             |
| [`195936e0`](https://github.com/NixOS/nixpkgs/commit/195936e03a08384eec83391f73c28af6b3a17805) | `` blockattack: 2.8.0 -> 2.9.0 ``                                             |
| [`abaecccc`](https://github.com/NixOS/nixpkgs/commit/abaecccc88dae6bcd6b5fcc47702f1929a263b58) | `` blockattack: nixfmt ``                                                     |