### PR TITLE
chore(flake/nixpkgs): `5710852b` -> `bfb7a882`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716330097,
-        "narHash": "sha256-8BO3B7e3BiyIDsaKA0tY8O88rClYRTjvAp66y+VBUeU=",
+        "lastModified": 1716509168,
+        "narHash": "sha256-4zSIhSRRIoEBwjbPm3YiGtbd8HDWzFxJjw5DYSDy1n8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5710852ba686cc1fd0d3b8e22b3117d43ba374c2",
+        "rev": "bfb7a882678e518398ce9a31a881538679f6f092",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                               |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
| [`a46ce7c7`](https://github.com/NixOS/nixpkgs/commit/a46ce7c77d9d9ee6af56196915106f6fb7b66c2b) | `` svelte-language-server: convert to buildNpmPackage ``                                              |
| [`5771dbfa`](https://github.com/NixOS/nixpkgs/commit/5771dbfa7d2f33c4d2bb417ec365282707e9156c) | `` bicep: fix updater script ``                                                                       |
| [`44744fc8`](https://github.com/NixOS/nixpkgs/commit/44744fc83f3ce1034eaf0b6cbb245a88234a42fe) | `` githooks.tests: fix eval ``                                                                        |
| [`0f3add33`](https://github.com/NixOS/nixpkgs/commit/0f3add331c6a4709bbe5f6f39ba99e3207775d6d) | `` segger-jlink: 794l -> 796b ``                                                                      |
| [`234f4db7`](https://github.com/NixOS/nixpkgs/commit/234f4db797d0a64bd2995601f15fd12c2394157f) | `` nixos/snapper, nixos/borgbackup: Fix module doc typo ``                                            |
| [`a1090beb`](https://github.com/NixOS/nixpkgs/commit/a1090bebdcca0c8eb7f60c475f67ef7fedd471ff) | `` gobang: unbreak, modernize ``                                                                      |
| [`4c627d7a`](https://github.com/NixOS/nixpkgs/commit/4c627d7adc3303ab9a5c272129c38dda585c6c54) | `` surrealdb: 1.5.0 -> 1.5.1 ``                                                                       |
| [`30e7e416`](https://github.com/NixOS/nixpkgs/commit/30e7e4163bb4fee3e816f917ce3cad29bd4447a3) | `` bicep: 0.26.54 -> 0.27.1 ``                                                                        |
| [`69b8e69d`](https://github.com/NixOS/nixpkgs/commit/69b8e69de7b66d4b09ca420cbb413c7001d977dc) | `` ideamaker: init at 4.3.3 ``                                                                        |
| [`01152519`](https://github.com/NixOS/nixpkgs/commit/01152519d6cde79a4077d0cf98cf80e2acf8ebdc) | `` nixos/tests/lomiri: Fix sound indicator subtest name ``                                            |
| [`d29e469f`](https://github.com/NixOS/nixpkgs/commit/d29e469f2a129a40b232760d0cd282f36a0cdaf9) | `` nixos/lomiri: Add display indicator ``                                                             |
| [`d4a51831`](https://github.com/NixOS/nixpkgs/commit/d4a518318044dbb3c842905ca4ab42f6ed544c5b) | `` ayatana-indicator-display: init at 24.5.0 ``                                                       |
| [`cfafdab4`](https://github.com/NixOS/nixpkgs/commit/cfafdab46c101dc901981863504d7e1c5c13cb22) | `` nextdns: 1.43.3 -> 1.43.4 ``                                                                       |
| [`7ebf5ff3`](https://github.com/NixOS/nixpkgs/commit/7ebf5ff345cbc90245b23336378cb9e98047e17b) | `` govulncheck: 1.1.0 -> 1.1.1 ``                                                                     |
| [`c64e560c`](https://github.com/NixOS/nixpkgs/commit/c64e560c86276d33f141703e9125a91fb817dbb8) | `` nixos/hydra: fix typo in hydra init script ``                                                      |
| [`72d5d19b`](https://github.com/NixOS/nixpkgs/commit/72d5d19b5789b5dd92c31fbe4cf6dd26704f62db) | `` stalwart-mail: 0.8.0 -> 0.8.1 ``                                                                   |
| [`197d6261`](https://github.com/NixOS/nixpkgs/commit/197d6261ebf862d7375d61b9973dfa4e10606103) | `` python311Packages.sphinxcontrib-ditaa: init at 1.0.2 ``                                            |
| [`cddbd427`](https://github.com/NixOS/nixpkgs/commit/cddbd427672e9e99bb9a8bf02b42ff59ee064bf3) | `` google-chrome: 125.0.6422.60 -> 125.0.6422.76 ``                                                   |
| [`3b70ff97`](https://github.com/NixOS/nixpkgs/commit/3b70ff975de01550f80860184d3d3deae997bbba) | `` bazel-buildtools: 7.1.1 -> 7.1.2 ``                                                                |
| [`c7d9fae3`](https://github.com/NixOS/nixpkgs/commit/c7d9fae3fd4d4736df692f63528292dfa450f307) | `` kdePackages: Gear 24.02 -> 24.05 ``                                                                |
| [`4731605e`](https://github.com/NixOS/nixpkgs/commit/4731605e889c7062907f1fd9bb3bc6cb198144be) | `` mediasynclite: init at 0.4.2 (#294716) ``                                                          |
| [`7496ea87`](https://github.com/NixOS/nixpkgs/commit/7496ea87763ae3d91f45da42805e4d7b10219849) | `` hyprlang: 0.5.1 -> 0.5.2 ``                                                                        |
| [`afffe11b`](https://github.com/NixOS/nixpkgs/commit/afffe11b2e264c52ea8334188e3947192ad86c8b) | `` python311Packages.svgelements: fix tests ``                                                        |
| [`1f5606f6`](https://github.com/NixOS/nixpkgs/commit/1f5606f6adef7cfe72869d507554e317719f9c06) | `` python312Packages.pyecowitt: refactor ``                                                           |
| [`d2305783`](https://github.com/NixOS/nixpkgs/commit/d2305783db0509dcf2e3ab897b8b91707874251d) | `` amarok: 2.9.71 -> 3.0.0 ``                                                                         |
| [`d9fae5e2`](https://github.com/NixOS/nixpkgs/commit/d9fae5e20dbb3017973cba1fa8d58318e2cb1d30) | `` python312Packages.pyedimax: refactor ``                                                            |
| [`143e613b`](https://github.com/NixOS/nixpkgs/commit/143e613bee6b3ec4a34bda043577279d4c054e80) | `` python311Packages.qgrid: fix python 3.12 compatibility ``                                          |
| [`c48dd1b4`](https://github.com/NixOS/nixpkgs/commit/c48dd1b43abf0a25936991d4685c5592e040a372) | `` goimports-reviser: 3.6.4 -> 3.6.5 ``                                                               |
| [`1461dbbe`](https://github.com/NixOS/nixpkgs/commit/1461dbbee35356d6aea102da072df380b0a5749c) | `` ocamlPackages.eio_*: inherit patches from eio ``                                                   |
| [`1c64a2fb`](https://github.com/NixOS/nixpkgs/commit/1c64a2fb1102be96303282a17f613ad7caeb72b7) | `` python312Packages.faraday-plugins: refactor ``                                                     |
| [`28647592`](https://github.com/NixOS/nixpkgs/commit/2864759231ca861b876bda3a083788b784cefad3) | `` python312Packages.faraday-plugins: 1.17.0 -> 1.18.0 ``                                             |
| [`f3b254da`](https://github.com/NixOS/nixpkgs/commit/f3b254dae286f477ec7cee9841af86f274392240) | `` python312Packages.faraday-agent-parameters-types: refactor ``                                      |
| [`cd71793b`](https://github.com/NixOS/nixpkgs/commit/cd71793bb2e146b673329269c4e40ad5ee310daa) | `` python312Packages.faraday-agent-parameters-types: 1.5.1 -> 1.6.0 ``                                |
| [`2ba59d41`](https://github.com/NixOS/nixpkgs/commit/2ba59d41ddd852a2701dbd0e72fd9a5bbf002281) | `` eksctl: 0.177.0 -> 0.178.0 ``                                                                      |
| [`cc68d492`](https://github.com/NixOS/nixpkgs/commit/cc68d49224ce61ed8b0c1925248d6246a0f28352) | `` cloud-nuke: 0.35.0 -> 0.36.0 ``                                                                    |
| [`ddfeae52`](https://github.com/NixOS/nixpkgs/commit/ddfeae5217ab2e052547ac254d26a8ea2ede4528) | `` pythonPackages: remove unused fetchpath arguments ``                                               |
| [`0989d93c`](https://github.com/NixOS/nixpkgs/commit/0989d93c00d66d2b12e1dbdf8c041705c9481823) | `` sd-switch: 0.3.0 -> 0.4.0 ``                                                                       |
| [`95a3cca9`](https://github.com/NixOS/nixpkgs/commit/95a3cca9cb4addc8da963d1351309ac60d700c9b) | `` multipath-tools: use --replace-fail in substitutions ``                                            |
| [`92bd0804`](https://github.com/NixOS/nixpkgs/commit/92bd0804a915c6de802af524c8b129d164ff24b0) | `` multipath-tools: backport build fix for musl libc 1.2.5 ``                                         |
| [`ccbea646`](https://github.com/NixOS/nixpkgs/commit/ccbea646d972374de52a83587ec6ebd1fb3d03e6) | `` multipath-tools: 0.9.6 -> 0.9.8 ``                                                                 |
| [`622ccf42`](https://github.com/NixOS/nixpkgs/commit/622ccf42c2cf98553c7a79522b718a16a37a3ec3) | `` nixosTests.nixos-test-driver: fix ruff check ``                                                    |
| [`84020441`](https://github.com/NixOS/nixpkgs/commit/84020441635dd16ecd5b06a23f5d57949c1358ad) | `` python311Packages.pyside6: fix build with Qt 6.7.1 ``                                              |
| [`eb042e72`](https://github.com/NixOS/nixpkgs/commit/eb042e727abff5ea1c192c47cdddc8e5c823b5fb) | `` python311Packages.manifestoo-core: 1.5 -> 1.6 ``                                                   |
| [`66ff0e15`](https://github.com/NixOS/nixpkgs/commit/66ff0e159d05ea5a1533c8485bb4024e1790fad2) | `` vimPlugins.nvim-snippets: init at 2024-02-07 ``                                                    |
| [`a5a47936`](https://github.com/NixOS/nixpkgs/commit/a5a479363d84c9dd9fdaa66347e17b95e6f22799) | `` amber-lang: init at 0.3.1-alpha ``                                                                 |
| [`56141e22`](https://github.com/NixOS/nixpkgs/commit/56141e2236e2607f3e54858a9617b2eb8b4adee8) | `` nixos/wireguard: add option preShutdown for commands called before interface deletion (#310345) `` |
| [`97e00828`](https://github.com/NixOS/nixpkgs/commit/97e008283acb1e5bbcccc8187c3d18cb8eaed8ab) | `` level-zero: 1.16.15 -> 1.17.2, add key packages to passthru.tests ``                               |
| [`d20a86cc`](https://github.com/NixOS/nixpkgs/commit/d20a86ccc104e906c057019e69fca4416ecb0258) | `` pkgs/development/libraries: remove unused fetchpatch and other arguments (#313402) ``              |
| [`fd374e94`](https://github.com/NixOS/nixpkgs/commit/fd374e94e971ed243840c4425fd715e67eb8561c) | `` python311Packages.python-ironicclient: fix dependencies after #310075 ``                           |
| [`e69199ed`](https://github.com/NixOS/nixpkgs/commit/e69199ed303799ab67b9065860066d7bb2f0ebe3) | `` hmcl: 3.5.7 -> 3.5.8 ``                                                                            |
| [`6360b911`](https://github.com/NixOS/nixpkgs/commit/6360b911311ea656d40fa6eba22e5e31c43ad990) | `` awslogs: 0.14.0 -> 0.15.0 ``                                                                       |
| [`2db20f93`](https://github.com/NixOS/nixpkgs/commit/2db20f930c231c6e0ef4f340bfef30ff1fe7cfed) | `` python311Packages.pyenvisalink: 4.6 -> 4.7 ``                                                      |
| [`3328b40f`](https://github.com/NixOS/nixpkgs/commit/3328b40f27fe1dd9ca7e367970fa01adf8d346e2) | `` autotiling: 1.9.2 -> 1.9.3 ``                                                                      |
| [`79cba4fa`](https://github.com/NixOS/nixpkgs/commit/79cba4fa1985e287bf63eca4a8d9632d159d29af) | `` python312Packages.aioxmpp: disable failing tests on Python 3.12 ``                                 |
| [`c4bfea54`](https://github.com/NixOS/nixpkgs/commit/c4bfea54cad62dcb50741caa609dd06d0d584802) | `` python311Packages.aioxmpp: refactor ``                                                             |
| [`7c2e8332`](https://github.com/NixOS/nixpkgs/commit/7c2e833237c200a999a012154bde9308e61783ee) | `` metasploit: 6.4.9 -> 6.4.10 ``                                                                     |
| [`86f240d2`](https://github.com/NixOS/nixpkgs/commit/86f240d2a5327152b5b27fc61a76b2633eeb35ac) | `` r0vm: init at 0.21.0 ``                                                                            |
| [`51c39ac7`](https://github.com/NixOS/nixpkgs/commit/51c39ac7acc44d4130041bad773c0e618400109a) | `` swego: format with nixfmt ``                                                                       |
| [`dc011869`](https://github.com/NixOS/nixpkgs/commit/dc0118692a7c47c24cb920f0c121bf8cf317775e) | `` swego: refactor ``                                                                                 |
| [`f1dfd966`](https://github.com/NixOS/nixpkgs/commit/f1dfd96632a5e7d83abd8eee3771159f7c1b0a43) | `` python312Packages.aiosasl: fix broken tests on Python 3.12 ``                                      |
| [`85c30125`](https://github.com/NixOS/nixpkgs/commit/85c301252a5d34e749bf13282a346ddddcf52f9e) | `` .git-blame-ignore-revs: add PHP packages reformating ``                                            |
| [`2c4b8f11`](https://github.com/NixOS/nixpkgs/commit/2c4b8f11935fab5edb58c61e574949fc3f1790ea) | `` edge-runtime: 1.14.0 -> 1.53.1 ``                                                                  |
| [`15a381be`](https://github.com/NixOS/nixpkgs/commit/15a381be44ce630f086a1e3cc14ba94935db931b) | `` python312Packages.strawberry-graphql: 0.219.2 -> 0.230.0 ``                                        |
| [`e05e1737`](https://github.com/NixOS/nixpkgs/commit/e05e1737b39e6dcb35b25e1795bd58ec7d597a2a) | `` python312Packages.strawberry-graphql: refactor ``                                                  |
| [`f70ed7a5`](https://github.com/NixOS/nixpkgs/commit/f70ed7a5cbc262decaeb0921f057309847b8c621) | `` roave-backward-compatibility-check: init at 8.8.0 ``                                               |
| [`aa7a7a91`](https://github.com/NixOS/nixpkgs/commit/aa7a7a91eda0c9923ff5bb0cf04c97dec7cdbfda) | `` wapiti: format with nixfmt ``                                                                      |
| [`6abca390`](https://github.com/NixOS/nixpkgs/commit/6abca390a18180719047fdb5f3a106bdfbf0a140) | `` wapiti: refactor ``                                                                                |
| [`31072788`](https://github.com/NixOS/nixpkgs/commit/310727880651a6f954400c58d808871ee60103cc) | `` python312Packages.aiocache: disable performance tests ``                                           |
| [`aee13d3d`](https://github.com/NixOS/nixpkgs/commit/aee13d3d9aaee0d1252de4863f3c818cec5f303f) | `` nixos/wyoming*: depend on network-online.target ``                                                 |
| [`0cb46743`](https://github.com/NixOS/nixpkgs/commit/0cb467431976ffba7c2cb31020756c1ba764fa4a) | `` doc: autogenerate python interpreter table (#313408) ``                                            |
| [`7721a54c`](https://github.com/NixOS/nixpkgs/commit/7721a54cc1d4d422f1ed3e1e8384fd2597ff0107) | `` python312Packages.datashape: fix build ``                                                          |
| [`a3b69628`](https://github.com/NixOS/nixpkgs/commit/a3b69628898f5389f57142b4343ed8e602029c8b) | `` dyndnsc: format with nixfmt ``                                                                     |
| [`ed907dda`](https://github.com/NixOS/nixpkgs/commit/ed907ddac82fceb5701ee82eb36835de44dddfa8) | `` dyndnsc: refactor ``                                                                               |
| [`5d515c37`](https://github.com/NixOS/nixpkgs/commit/5d515c373e8dd2db5e3087a3cf56d961fb8f1d87) | `` nixos/kea: make ctrl-agent want network-online.target ``                                           |
| [`254dbdcc`](https://github.com/NixOS/nixpkgs/commit/254dbdcc6296ba83381e218bf755b939c91a7f8e) | `` grafanaPlugins.grafana-oncall-app: init at 1.5.1 ``                                                |
| [`ea1a3f4b`](https://github.com/NixOS/nixpkgs/commit/ea1a3f4b3ac7253558354a8c6e5601a74009bdf5) | `` python312Packages.boto3-stubs: 1.34.110 -> 1.34.111 ``                                             |
| [`1349027d`](https://github.com/NixOS/nixpkgs/commit/1349027dbc4f7fe5752b7c5172b0df77c92aa672) | `` python312Packages.aioquic: 0.9.25 -> 1.0.0 ``                                                      |
| [`1ee42197`](https://github.com/NixOS/nixpkgs/commit/1ee4219782a5d7108461c6e318473212cac63ab3) | `` checkov: 3.2.92 -> 3.2.106 ``                                                                      |
| [`e5bb0127`](https://github.com/NixOS/nixpkgs/commit/e5bb012796cd740bef1850d848ad4ab1026093b3) | `` namespace-cli: 0.0.371 -> 0.0.372 ``                                                               |
| [`980e7754`](https://github.com/NixOS/nixpkgs/commit/980e77541f9d6b7468bfab23d4b811ea85841110) | `` python312Packages.bluetooth-sensor-state-data: refactor ``                                         |
| [`e1ba82b9`](https://github.com/NixOS/nixpkgs/commit/e1ba82b92b347939d25168867d9ed5021cc348f5) | `` python312Packages.bluetooth-sensor-state-data: 1.6.2 -> 1.7.0 ``                                   |
| [`8b39f816`](https://github.com/NixOS/nixpkgs/commit/8b39f81674027d59cc26511c602bb6dc68c5ab53) | `` terraform: 1.8.3 -> 1.8.4 ``                                                                       |
| [`bf8a1a8c`](https://github.com/NixOS/nixpkgs/commit/bf8a1a8c4e02a4fd73eacb7e8732deba1ac6a6f9) | `` python312Packages.pydeconz: refactor ``                                                            |
| [`50857283`](https://github.com/NixOS/nixpkgs/commit/50857283418492f3ecbd43ab5034dedf79c7409a) | `` calamares-nixos-extensions: 0.3.15 -> 0.3.16 ``                                                    |
| [`d28cf9c0`](https://github.com/NixOS/nixpkgs/commit/d28cf9c00b552a9630649c6032a4018dc4c45ff6) | `` neovim-unwrapped: fix markdown_inline tree-sitter parser ``                                        |
| [`3c985ee7`](https://github.com/NixOS/nixpkgs/commit/3c985ee7da83e6e15fecafb2ebd3630bdca3107d) | `` myks: 4.1.1 -> 4.1.2 ``                                                                            |
| [`3ec93b0d`](https://github.com/NixOS/nixpkgs/commit/3ec93b0dbdb3eaf31545d94580516e2ff81029b3) | `` files-cli: 2.13.49 -> 2.13.50 ``                                                                   |
| [`2de3b004`](https://github.com/NixOS/nixpkgs/commit/2de3b0044aa34973abb88356788ce0f22d09f962) | `` cargo-component: 0.12.0 -> 0.13.0 ``                                                               |
| [`3ee89bd0`](https://github.com/NixOS/nixpkgs/commit/3ee89bd08e219a5b950322c5366dd2f2e5044d7e) | `` atmos: 1.72.0 -> 1.73.0 ``                                                                         |
| [`a7094f76`](https://github.com/NixOS/nixpkgs/commit/a7094f7697b1fcf7b345fa027fc1d2ae98da9368) | `` swego: 1.0 -> 1.1 ``                                                                               |
| [`724e4680`](https://github.com/NixOS/nixpkgs/commit/724e4680a8c3c2fb6ecc0fd7a8682fbd9e59a9ec) | `` tmux-mem-cpu-load: 3.8.0 -> 3.8.1 ``                                                               |
| [`4a3b0128`](https://github.com/NixOS/nixpkgs/commit/4a3b0128511e0725423c6370324d1eb039b4fac9) | `` ruff: 0.4.4 -> 0.4.5 ``                                                                            |
| [`1e4ff676`](https://github.com/NixOS/nixpkgs/commit/1e4ff676da0f936e057d86153deeeb0c54b8d009) | `` nezha-agent: 0.16.8 -> 0.16.9 ``                                                                   |