### PR TITLE
chore(flake/nixpkgs): `ad57eef4` -> `57610d2f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716948383,
-        "narHash": "sha256-SzDKxseEcHR5KzPXLwsemyTR/kaM9whxeiJohbL04rs=",
+        "lastModified": 1717196966,
+        "narHash": "sha256-yZKhxVIKd2lsbOqYd5iDoUIwsRZFqE87smE2Vzf6Ck0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ad57eef4ef0659193044870c731987a6df5cf56b",
+        "rev": "57610d2f8f0937f39dbd72251e9614b1561942d8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                    |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`64c4d20d`](https://github.com/NixOS/nixpkgs/commit/64c4d20d62c29ab6aeb3056ceab17685acd7d926) | `` linuxPackages.nvidiaPackages.vulkan_beta: 550.40.61 -> 550.40.63 ``                     |
| [`4a2828b2`](https://github.com/NixOS/nixpkgs/commit/4a2828b20a03b952a4af9a9b681d1771a78875c0) | `` uxn: 1.0-unstable-2024-05-10 -> 1.0-unstable-2024-05-30 ``                              |
| [`81537e06`](https://github.com/NixOS/nixpkgs/commit/81537e065694b33b0e28632cd105e0d6c576d50b) | `` coqPackages.mathcomp-word: 3.1 → 3.2; 2.3 → 2.4 ``                                      |
| [`d3e8bd6c`](https://github.com/NixOS/nixpkgs/commit/d3e8bd6cae4828bd130a538963da5aa291320b5c) | `` vscode-extensions.danielgavin.ols: init 0.1.28 ``                                       |
| [`7f5aedec`](https://github.com/NixOS/nixpkgs/commit/7f5aedecb5e730321e1715130b904a84c4c60c34) | `` melpaBuild: add files parameter to specify :files of recipe ``                          |
| [`962ec471`](https://github.com/NixOS/nixpkgs/commit/962ec471bac8d85e001450ff9d9ec860f7a7bbdb) | `` gimpPlugins.gmic: 3.3.5 -> 3.3.6 ``                                                     |
| [`6c9f79c1`](https://github.com/NixOS/nixpkgs/commit/6c9f79c133f60a2d618b99032f8bc877b3be63e6) | `` melpaBuild: add doc and default value for recipe ``                                     |
| [`d95b1060`](https://github.com/NixOS/nixpkgs/commit/d95b1060ca298c62f56de90d0bf755c4c6b48e0a) | `` Release NixOS 24.05 ``                                                                  |
| [`428dfcb0`](https://github.com/NixOS/nixpkgs/commit/428dfcb0073c399e18a61bcc4077c87f1aa2a927) | `` melpaBuild: add doc and default value for commit ``                                     |
| [`7da279c3`](https://github.com/NixOS/nixpkgs/commit/7da279c3b9570fd1c2a0d1caf1d16bbdca8c1854) | `` vengi-tools: 0.0.31 -> 0.0.32 ``                                                        |
| [`11fd7fbf`](https://github.com/NixOS/nixpkgs/commit/11fd7fbf256cea6d96e75b8bd7f0530f19a06914) | `` gpxsee: 13.20 -> 13.21 ``                                                               |
| [`fc168914`](https://github.com/NixOS/nixpkgs/commit/fc1689148040bcaf91ffece8c899d0d1aa98044c) | `` plasma-workspace: 5.27.11 -> 5.27.11.1 ``                                               |
| [`6f09f555`](https://github.com/NixOS/nixpkgs/commit/6f09f555e050fcc7ab2408072b62ffd7c0cbdb65) | `` git-mit: 5.12.202 -> 5.12.203 ``                                                        |
| [`a4e1477b`](https://github.com/NixOS/nixpkgs/commit/a4e1477b615ac47995219561199269537f02965c) | `` kdePackages.plasma-workspace: 6.0.5 -> 6.0.5.1 ``                                       |
| [`282935e6`](https://github.com/NixOS/nixpkgs/commit/282935e670f4bfccd64bf18da165d8fd588621fa) | `` jami: 20240430.0 -> 20240529.0 ``                                                       |
| [`5a551971`](https://github.com/NixOS/nixpkgs/commit/5a5519713422f6d7c1adea307235056820a68233) | `` squawk: 0.28.0 -> 0.29.0 ``                                                             |
| [`ce28e96d`](https://github.com/NixOS/nixpkgs/commit/ce28e96db0d74d28463bb3601f740f73a8b81e7e) | `` phrase-cli: 2.27.0 -> 2.27.1 ``                                                         |
| [`1ee0e2dc`](https://github.com/NixOS/nixpkgs/commit/1ee0e2dcfecd93168f757deff4ed33d7d574484c) | `` doc: improve the look of terms in definition lists (#313891) ``                         |
| [`0069b09c`](https://github.com/NixOS/nixpkgs/commit/0069b09cd7de68bf238219bcf7b76a8ea78bc8a5) | `` grafana-kiosk: 1.0.6 -> 1.0.7 ``                                                        |
| [`0600ce8b`](https://github.com/NixOS/nixpkgs/commit/0600ce8b545de972cc7eb702f9ef4260bba67d8f) | `` vimPlugins.faster-nvim: init at 2024-04-11 ``                                           |
| [`a5632e32`](https://github.com/NixOS/nixpkgs/commit/a5632e327c491dedc2de0208869193f039f61696) | `` ocamlPackages.yojson: 2.1.2 → 2.2.0 ``                                                  |
| [`0e270c5e`](https://github.com/NixOS/nixpkgs/commit/0e270c5e4bea3e0e98c9593179234d0755d11122) | `` weechat: 4.3.0 -> 4.3.1 ``                                                              |
| [`d148e5a6`](https://github.com/NixOS/nixpkgs/commit/d148e5a6dad22903299e1264e848e0127d30ece2) | `` ccache: format with `nixfmt-rfc-style` ``                                               |
| [`2944aeb2`](https://github.com/NixOS/nixpkgs/commit/2944aeb2c64d9e8eb060e14ae1762e208c53b3bb) | `` ccache: 4.9.1 -> 4.10 ``                                                                |
| [`2e5d8f90`](https://github.com/NixOS/nixpkgs/commit/2e5d8f90046ad19303fcc8cb8d33bd58a0cf93b3) | `` python311Packages.pyathena: 3.8.2 -> 3.8.3 ``                                           |
| [`9784118a`](https://github.com/NixOS/nixpkgs/commit/9784118a2f5b5fc9299f07160dc4b1b84ab8822b) | `` micropython: 1.22.2 -> 1.23.0 ``                                                        |
| [`3da336fc`](https://github.com/NixOS/nixpkgs/commit/3da336fc7936314644939bfc2bf7489249bf8539) | `` nixos/ladybird: init ``                                                                 |
| [`e31769a3`](https://github.com/NixOS/nixpkgs/commit/e31769a346321f9bb76747c518bc5a3775c458d8) | `` ladybird: search for fonts in NixOS-specific paths ``                                   |
| [`e4eb54eb`](https://github.com/NixOS/nixpkgs/commit/e4eb54eb19764b34f8374af5daf37efcccf2807d) | `` sublime4-dev: 4173 → 4175 ``                                                            |
| [`dc5943e1`](https://github.com/NixOS/nixpkgs/commit/dc5943e19d52dc6ad2f921c4a409c4549af99161) | `` jq-lsp: 0.1.2 -> 0.1.3 ``                                                               |
| [`03266530`](https://github.com/NixOS/nixpkgs/commit/03266530c8b87d60365fe1da9878caf18c06f9fa) | `` oh-my-posh: 20.2.0 -> 21.0.1 ``                                                         |
| [`ab794928`](https://github.com/NixOS/nixpkgs/commit/ab79492899c0a76a9c2eed79a6a216cceeeee0d4) | `` python311Packages.wasserstein: fix build on aarch64-linux ``                            |
| [`3cf43046`](https://github.com/NixOS/nixpkgs/commit/3cf43046921d72c543a4e96611ce12b58248f877) | `` Revert "nixos/networking: use mkIfs on the inner attributes" ``                         |
| [`51a31a6f`](https://github.com/NixOS/nixpkgs/commit/51a31a6f4039e0195317d085b969d7e0e6ff3366) | `` python312Packages.stringly: drop checkPhase ``                                          |
| [`682927f3`](https://github.com/NixOS/nixpkgs/commit/682927f3ad70475a940d81572c2fb23704f2d88d) | `` python312Packages.treelog: drop checkPhase ``                                           |
| [`980a4dc9`](https://github.com/NixOS/nixpkgs/commit/980a4dc91324166f4493359db63ddc48f5f8373c) | `` python311Packages.python-musicpd: fix build ``                                          |
| [`7c121de6`](https://github.com/NixOS/nixpkgs/commit/7c121de665bb19ac84c5df43c3de2d1c0d0a0427) | `` toml-f: fix build on aarch64-linux ``                                                   |
| [`37733ad1`](https://github.com/NixOS/nixpkgs/commit/37733ad1bac4959e6805d11ebdd378855244258d) | `` home-assistant: pin pymelcloud at 2.5.9 ``                                              |
| [`ad99b832`](https://github.com/NixOS/nixpkgs/commit/ad99b8322c05b546c16e03ca164cd63b3abba987) | `` audiness: 0.4.0 -> 0.5.0 ``                                                             |
| [`70b62ca4`](https://github.com/NixOS/nixpkgs/commit/70b62ca4931284435f5b6b4c68d66611304b64c8) | `` python311Packages.testcontainers: 4.5.0 -> 4.5.1 ``                                     |
| [`87446101`](https://github.com/NixOS/nixpkgs/commit/87446101d3bda8aea180610a157bdbd96ef5c8a4) | `` python311Packages.rapidfuzz: 3.9.1 -> 3.9.2 ``                                          |
| [`35c696f4`](https://github.com/NixOS/nixpkgs/commit/35c696f49f8e6d562babbd1a270784836b2487ce) | `` nginxMainline: 1.25.4 -> 1.27.0 ``                                                      |
| [`25e4a15f`](https://github.com/NixOS/nixpkgs/commit/25e4a15f2ade9d8fb33a97603cd99652e6870d42) | `` nginx: 1.26.0 -> 1.26.1 ``                                                              |
| [`9d1c89f9`](https://github.com/NixOS/nixpkgs/commit/9d1c89f9eb061053429936493659300f84690ecf) | `` ananicy-rules-cachyos: 0-unstable-2024-05-10 -> 0-unstable-2024-05-28 ``                |
| [`50a392e2`](https://github.com/NixOS/nixpkgs/commit/50a392e22a85db859fc0e1990f1a3dd7c8434026) | `` waylyrics: 0.3.9 -> 0.3.10 ``                                                           |
| [`f967253c`](https://github.com/NixOS/nixpkgs/commit/f967253c4d763e057bcf6b7c8cde07f0c963fb61) | `` ockam: 0.124.0 -> 0.125.0 ``                                                            |
| [`336232de`](https://github.com/NixOS/nixpkgs/commit/336232debdc95311595c1ce56ef8690dcd334eda) | `` stalwart-mail: package upstream systemd unit ``                                         |
| [`dfa130e8`](https://github.com/NixOS/nixpkgs/commit/dfa130e828fc1612621802c83618685a5b6dfe92) | `` nixos/stalwart-mail: use upstream systemd unit ``                                       |
| [`6946c334`](https://github.com/NixOS/nixpkgs/commit/6946c3342ec5f5bbfa0c6d11e838ced350bfcec0) | `` julia.withPackages: be able to test different julia attrs ``                            |
| [`4ebab7e8`](https://github.com/NixOS/nixpkgs/commit/4ebab7e86d60dbe77a7d2da6436895edc05e1ca4) | `` julia.withPackages: fix compatibility with new git security features (#315890) ``       |
| [`cb77fe85`](https://github.com/NixOS/nixpkgs/commit/cb77fe8561a431afb7fbe36b06d4f105d1994dbf) | `` Numbat: 1.11 -> 1.12 ``                                                                 |
| [`d3139194`](https://github.com/NixOS/nixpkgs/commit/d313919498cdebe8c1c3d80509c4b6265f9b329a) | `` fastfetch: 2.13.2 -> 2.14.0 ``                                                          |
| [`c68a67f2`](https://github.com/NixOS/nixpkgs/commit/c68a67f2b58ea37482d9271055764315749a7bad) | `` retroarchBare: 1.18.0 -> 1.19.0 ``                                                      |
| [`0b8cee8a`](https://github.com/NixOS/nixpkgs/commit/0b8cee8ae4951492f7e010a28c9ff6b1ef942f27) | `` planify: build with the -gtk4 variant of evolution-data-server ``                       |
| [`ffac7a88`](https://github.com/NixOS/nixpkgs/commit/ffac7a885210c648f1b0041346a7ed586a7da751) | `` bitwarden-menu: 0.4.1 -> 0.4.3 ``                                                       |
| [`46fff143`](https://github.com/NixOS/nixpkgs/commit/46fff1439bfc325bfd861f7ae0c53993a9fd9f5d) | `` telegram-desktop: 5.0.2 -> 5.0.6 ``                                                     |
| [`8bd0df64`](https://github.com/NixOS/nixpkgs/commit/8bd0df64ad2b8f94870c6d346554102adc6b8a33) | `` smtprelay: 1.11.0 -> 1.11.1 ``                                                          |
| [`06b1b19b`](https://github.com/NixOS/nixpkgs/commit/06b1b19bcb00b36f5843f67b1a7498877db202e4) | `` python311Packages.uv: 0.2.4 -> 0.2.5 ``                                                 |
| [`9188748d`](https://github.com/NixOS/nixpkgs/commit/9188748d07d5ceb68592ca326d2d45a91309f722) | `` yggdrasil: 0.5.5 -> 0.5.6 ``                                                            |
| [`6ee49a58`](https://github.com/NixOS/nixpkgs/commit/6ee49a5805cb54db58631806ea6febdf5c3f9fa6) | `` wit-bindgen: 0.25.0 -> 0.26.0 ``                                                        |
| [`09f22ab8`](https://github.com/NixOS/nixpkgs/commit/09f22ab80f2db2a39e7d28181a8b5f2006610a37) | `` python311Packages.httpauth: 0.4 -> 0.4.1 ``                                             |
| [`67f0bfe6`](https://github.com/NixOS/nixpkgs/commit/67f0bfe68a6d31e989a30d803d0ca1139f17d80f) | `` ssm-session-manager-plugin: 1.2.553.0 -> 1.2.633.0 ``                                   |
| [`2207d3e0`](https://github.com/NixOS/nixpkgs/commit/2207d3e08e5aa2582e30c5c23da58dae1de27c3f) | `` simdjson: 3.9.2 -> 3.9.3 ``                                                             |
| [`b25101d1`](https://github.com/NixOS/nixpkgs/commit/b25101d1fb26045f3901a9e7832a04fde02c3946) | `` doc: fix testers.testEqualContents fragment link ``                                     |
| [`a51e8e31`](https://github.com/NixOS/nixpkgs/commit/a51e8e319f2893fac80ebf992ec46a10788b872a) | `` mercure: 0.15.11 -> 0.16.0 ``                                                           |
| [`3fad23a5`](https://github.com/NixOS/nixpkgs/commit/3fad23a5e6e8cb2b18c9abb4bc337b59e6fb8d49) | `` grpc_cli: 1.64.0 -> 1.64.1 ``                                                           |
| [`520b8e53`](https://github.com/NixOS/nixpkgs/commit/520b8e536518564474fbeebd5818e57384f7624a) | `` hugo: 0.126.1 -> 0.126.2 ``                                                             |
| [`20fbc354`](https://github.com/NixOS/nixpkgs/commit/20fbc354595a9a7f0e63e1d612f245fab3e7d02f) | `` nrr: 0.9.1 -> 0.9.2 ``                                                                  |
| [`333da076`](https://github.com/NixOS/nixpkgs/commit/333da076b93bbe24c8a4dcf4d61920077c8270a6) | `` doctl: 1.106.0 -> 1.107.0 ``                                                            |
| [`9d7bd26b`](https://github.com/NixOS/nixpkgs/commit/9d7bd26bb0af9bb409acbdb4ec305e9f84459fb4) | `` open-policy-agent: 0.64.1 -> 0.65.0 ``                                                  |
| [`7816d85e`](https://github.com/NixOS/nixpkgs/commit/7816d85e07da98489a63a20f60191178ee95e320) | `` hermitcli: 0.39.1 -> 0.39.2 ``                                                          |
| [`5427948b`](https://github.com/NixOS/nixpkgs/commit/5427948b93257aee0d6a0f7363c13b79d2c8ac0a) | `` openfga: 1.5.3 -> 1.5.4 ``                                                              |
| [`d75fb173`](https://github.com/NixOS/nixpkgs/commit/d75fb173ce96d7cd891510f0432773fe9c6afcbe) | `` matugen: 2.2.0 -> 2.3.0 ``                                                              |
| [`b11dd94e`](https://github.com/NixOS/nixpkgs/commit/b11dd94ea7d23b3b632da9919a81997ca6e1c7d8) | `` bicep: mark as not broken on darwin ``                                                  |
| [`35ed6417`](https://github.com/NixOS/nixpkgs/commit/35ed64173b4c93e9f829f1858f0adca8b852f8c2) | `` aardvark-dns: 1.10.0 -> 1.11.0 ``                                                       |
| [`393d40fe`](https://github.com/NixOS/nixpkgs/commit/393d40fe59ef4a9b141fd904a3f3c4b6480b6513) | `` air: 1.52.0 -> 1.52.1 ``                                                                |
| [`f1c7c63c`](https://github.com/NixOS/nixpkgs/commit/f1c7c63c6927af48d05ac749d8fcea32538d2848) | `` Remove tomfitzhenry@ from some maintainership ``                                        |
| [`8c58b058`](https://github.com/NixOS/nixpkgs/commit/8c58b058810a24a0c6764eece796897c3079d2cd) | `` doc/release-notes: highlight desktop environment updates ``                             |
| [`93117562`](https://github.com/NixOS/nixpkgs/commit/93117562ee0b245b0704ab4ffdf527187a0658e8) | `` iosevka-bin: 30.0.1 -> 30.1.1 ``                                                        |
| [`0f6db436`](https://github.com/NixOS/nixpkgs/commit/0f6db436e82c099db38baed2c70429655845521f) | `` cmake-format: add meta.mainProgram ``                                                   |
| [`c1eae304`](https://github.com/NixOS/nixpkgs/commit/c1eae30445b0c16035f2519357a3e93ec73e2001) | `` bicep: add meta.mainProgram ``                                                          |
| [`a604ae56`](https://github.com/NixOS/nixpkgs/commit/a604ae5663a3b16549e24c482294bcb0d2c414d3) | `` edge-runtime: 1.53.2 -> 1.53.3 ``                                                       |
| [`9aa98049`](https://github.com/NixOS/nixpkgs/commit/9aa980497ae22565d8a309dad52f5ddf7ba8e90d) | `` backblaze-b2: fix cross compilation ``                                                  |
| [`31d08abf`](https://github.com/NixOS/nixpkgs/commit/31d08abf388bb7efd151028da9c662d28c04067b) | `` signalbackup-tools: 20240528-1 -> 20240530 ``                                           |
| [`4738ac47`](https://github.com/NixOS/nixpkgs/commit/4738ac4745c3bd5b44e4fda47377e544e29b525c) | `` ejson2env: 2.0.5 -> 2.0.6 ``                                                            |
| [`4c9c9a80`](https://github.com/NixOS/nixpkgs/commit/4c9c9a8004d7d6d82a2f5555766d772b84df7a7b) | `` terminator: 2.1.3 -> 2.1.4 ``                                                           |
| [`e6ca472a`](https://github.com/NixOS/nixpkgs/commit/e6ca472ac6e6f599ddbee2485f099254736fcc78) | `` libfmvoice: 0.0.0-unstable-2023-12-05 -> 0-unstable-2024-05-30 ``                       |
| [`78ecb919`](https://github.com/NixOS/nixpkgs/commit/78ecb9195e5ba9594709188f9af26b743f244040) | `` gnome.gnome-shell-extensions: patch GTop path for the GNOME System Monitor extension `` |
| [`8f3d1f9d`](https://github.com/NixOS/nixpkgs/commit/8f3d1f9d4ac56acb932fa92ce68c59102a58bcdf) | `` home-manager: 0-unstable-2024-05-23 -> 0-unstable-2024-05-30 ``                         |
| [`94a98119`](https://github.com/NixOS/nixpkgs/commit/94a981196fe0a39ac142938d91b496e5a78917c2) | `` qutip: 4.7.5 -> 5.0.2 ``                                                                |