### PR TITLE
chore(flake/nixpkgs): `051f9206` -> `e9ee548d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1717786204,
-        "narHash": "sha256-4q0s6m0GUcN7q+Y2DqD27iLvbcd1G50T2lv08kKxkSI=",
+        "lastModified": 1718318537,
+        "narHash": "sha256-4Zu0RYRcAY/VWuu6awwq4opuiD//ahpc2aFHg2CWqFY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "051f920625ab5aabe37c920346e3e69d7d34400e",
+        "rev": "e9ee548d90ff586a6471b4ae80ae9cfcbceb3420",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`50261c06`](https://github.com/NixOS/nixpkgs/commit/50261c0602f9df33074dae65c871d354517db4f7) | `` config.rust: update references from rustc ``                               |
| [`9c51d83b`](https://github.com/NixOS/nixpkgs/commit/9c51d83ba84f61e9ad7ccb8062d0760006dd7ad5) | `` forgejo: 7.0.3 -> 7.0.4 ``                                                 |
| [`6e11b531`](https://github.com/NixOS/nixpkgs/commit/6e11b53199679aeefd1023870a9b4aa06ede7c95) | `` python311Packages.unstructured: 0.14.4 -> 0.14.5 ``                        |
| [`ed21b753`](https://github.com/NixOS/nixpkgs/commit/ed21b753bb9cab729a1a846aead138389cd94b33) | `` vencord: 1.8.8 -> 1.8.9 ``                                                 |
| [`7d315962`](https://github.com/NixOS/nixpkgs/commit/7d31596266d642db778b0eeda36f6decb0d883f1) | `` python311Packages.nibe: 2.10.0 -> 2.10.1 ``                                |
| [`89fffd65`](https://github.com/NixOS/nixpkgs/commit/89fffd65586f5133372af5dd0274f07cc0bbeed3) | `` dracula-theme: 4.0.0-unstable-2024-06-03 -> 4.0.0-unstable-2024-06-11 ``   |
| [`0894cda8`](https://github.com/NixOS/nixpkgs/commit/0894cda89cb984301b99b085bdf18680c9ae0713) | `` rbspy: 0.21.0 -> 0.22.0 ``                                                 |
| [`75e61258`](https://github.com/NixOS/nixpkgs/commit/75e612587b347edf3b37ef43d3231ad5b3c8ac3a) | `` apt-offline: install manpage ``                                            |
| [`18214ff3`](https://github.com/NixOS/nixpkgs/commit/18214ff3c973768c304c686bdf3b61393d452ce0) | `` irrd: 4.4.2 -> 4.4.4; fix build (#319522) ``                               |
| [`42519bf8`](https://github.com/NixOS/nixpkgs/commit/42519bf8d4acaf2636ad2a4c7c9d817866958c46) | `` swego: 1.1 -> 1.12 ``                                                      |
| [`a24f70ac`](https://github.com/NixOS/nixpkgs/commit/a24f70ac885f6c86ed0f3abf16cabd9302037fa0) | `` namespace-cli: 0.0.374 -> 0.0.376 ``                                       |
| [`31a11499`](https://github.com/NixOS/nixpkgs/commit/31a114995864df307db2ac9bc7722afd628d660d) | `` python311Packages.clarifai-grpc: 10.5.0 -> 10.5.2 ``                       |
| [`ae296293`](https://github.com/NixOS/nixpkgs/commit/ae296293ac2142a48c69d7760a9c9757289bf94c) | `` regal: 0.23.0 -> 0.23.1 ``                                                 |
| [`37c81452`](https://github.com/NixOS/nixpkgs/commit/37c81452f0f043f93faa10efcaf920bf9b5cfc66) | `` typstyle: 0.11.25 -> 0.11.26 ``                                            |
| [`3746ee88`](https://github.com/NixOS/nixpkgs/commit/3746ee8800501947d4f3f9c5a517bfdcbf32342f) | `` ngtcp2-gnutls: 1.5.0 -> 1.6.0 ``                                           |
| [`e28852f3`](https://github.com/NixOS/nixpkgs/commit/e28852f372050848c5c97928f72ddeed75e0ce87) | `` phrase-cli: 2.27.1 -> 2.28.0 ``                                            |
| [`a21bf261`](https://github.com/NixOS/nixpkgs/commit/a21bf261a4070241f90d6d45e3e1d994c9db929a) | `` mackerel-agent: 0.81.0 -> 0.82.0 ``                                        |
| [`9c6276ea`](https://github.com/NixOS/nixpkgs/commit/9c6276ea2e59f4ca0c2f0092d573cd9408a6ac42) | `` naev: 0.11.4 -> 0.11.5 ``                                                  |
| [`d7d3e88b`](https://github.com/NixOS/nixpkgs/commit/d7d3e88bce755ac882782da8d081ac1cb9809aa4) | `` konstraint: 0.36.0 -> 0.37.0 ``                                            |
| [`25765e4b`](https://github.com/NixOS/nixpkgs/commit/25765e4bf26d23078011a83508573380c1ce684e) | `` fnm: 1.37.0 -> 1.37.1 ``                                                   |
| [`da21712b`](https://github.com/NixOS/nixpkgs/commit/da21712bc7424c4c1bb15649cc6fe6751b8d8e12) | `` kdePackages: Gear 24.05 -> 24.05.1 ``                                      |
| [`27376c9e`](https://github.com/NixOS/nixpkgs/commit/27376c9e1f2dd1aab53454b8b8a6f35aec381ff8) | `` ride: add patch to support later electron versions ``                      |
| [`31099f80`](https://github.com/NixOS/nixpkgs/commit/31099f80011419c43303fa003632d01ca1ec65cd) | `` aws-c-common: 0.9.17 -> 0.9.21 ``                                          |
| [`e34d62d8`](https://github.com/NixOS/nixpkgs/commit/e34d62d869c3fbd23ab7440628bfea28b1e176c2) | `` gitlab-container-registry: 4.1.0 -> 4.5.0 ``                               |
| [`7e9c87c6`](https://github.com/NixOS/nixpkgs/commit/7e9c87c67b97efa5c174fde31426a5df2369ab72) | `` gitlab: 16.10.6 -> 16.11.4 ``                                              |
| [`703c85cb`](https://github.com/NixOS/nixpkgs/commit/703c85cb9a69b9a0f80d40fb843679114c0d664a) | `` tidb: add Makuru as maintainer ``                                          |
| [`ce5f2b92`](https://github.com/NixOS/nixpkgs/commit/ce5f2b92987420063723f78efc8449c8e68d1132) | `` maintainers: add Makuru ``                                                 |
| [`364404d8`](https://github.com/NixOS/nixpkgs/commit/364404d8a8ce8a9168ecf208eea66e6298f4d002) | `` ollama: 0.1.42 -> 0.1.43 ``                                                |
| [`1a3cb5fc`](https://github.com/NixOS/nixpkgs/commit/1a3cb5fc1535a5d803dab11f1e87969ba5e7d5db) | `` tcsh: 6.24.12 -> 6.24.13 ``                                                |
| [`226beb4c`](https://github.com/NixOS/nixpkgs/commit/226beb4c3a85ce39eb5afd9ce27aa5b0cc47d8b3) | `` igvm-tooling: add katexochen as maintainer ``                              |
| [`fb9cdbda`](https://github.com/NixOS/nixpkgs/commit/fb9cdbda70e96d8570f351fd385862f50a009717) | `` chromium,electron-source: remove no longer needed version conditionals ``  |
| [`268ce0e5`](https://github.com/NixOS/nixpkgs/commit/268ce0e562875c1e0e846384fcd95b9241bb1214) | `` electron-source.electron_{27,28}: remove instead of marking them as EOL `` |
| [`88abc8f5`](https://github.com/NixOS/nixpkgs/commit/88abc8f5a7d923d62b3735c1157e60024516cd9b) | `` elixir_1_17: init at 1.17.0 ``                                             |
| [`b2d959d2`](https://github.com/NixOS/nixpkgs/commit/b2d959d25b461e8da182c111f7d8e4cb932e4667) | `` python312Packages.natural: init at 0.2.0 ``                                |
| [`43f62ef3`](https://github.com/NixOS/nixpkgs/commit/43f62ef3d03338b959a26ba28222058fa3153dc1) | `` bash-language-server: use pnpm.fetchDeps instead of node2nix ``            |
| [`f50c22a7`](https://github.com/NixOS/nixpkgs/commit/f50c22a7f284d257a97320d755947e94a2c612f7) | `` paperless-ngx: use headless ghostscript ``                                 |
| [`a06e115b`](https://github.com/NixOS/nixpkgs/commit/a06e115bbb8b6ce30331fdc7e89415c819cf2bc5) | `` devenv: 1.0.6 -> 1.0.7 ``                                                  |
| [`6959071f`](https://github.com/NixOS/nixpkgs/commit/6959071f7c372e7e8fb2ce1cb9da139b45f24750) | `` fluent-gtk-theme: move to pkgs/by-name ``                                  |
| [`4629a9f8`](https://github.com/NixOS/nixpkgs/commit/4629a9f8223b0d093b1895002b30d57d4d491e82) | `` fluent-gtk-theme 2024-04-28 -> 2024-06-12 ``                               |
| [`48c06216`](https://github.com/NixOS/nixpkgs/commit/48c06216f599c3b67864baed6b2b0642548ab147) | `` tandoor-recipes: fix drf tests ``                                          |
| [`c04fadea`](https://github.com/NixOS/nixpkgs/commit/c04fadeaa6dec5cbea14efc0ec27e929f7bb42c4) | `` paperless-ngx: fix drf tests ``                                            |
| [`f77d5bd6`](https://github.com/NixOS/nixpkgs/commit/f77d5bd637cd9b53f01c4ed5916e9c7483c0ccc2) | `` utterly-nord-plasma: fix installation ``                                   |
| [`9320ef94`](https://github.com/NixOS/nixpkgs/commit/9320ef944f68fffc2d8400841a94b2c3594329c7) | `` utterly-round-plasma-style: update ``                                      |
| [`4b2a8a6d`](https://github.com/NixOS/nixpkgs/commit/4b2a8a6d8efe0ea2f568255de3b795166aed6731) | `` pretalx: backport drf 3.15 support ``                                      |
| [`75d7ee7d`](https://github.com/NixOS/nixpkgs/commit/75d7ee7d8c938fea4d36e99ef3149fad7fb80891) | `` open-webui: Use `makeWrapperArgs`; Use env to disable hatch custom hook `` |
| [`e99a835a`](https://github.com/NixOS/nixpkgs/commit/e99a835a130c2b6d5e7c1443f1e79fe7df0142b3) | `` rl-2411: keep original unicode name. ``                                    |
| [`10d45b15`](https://github.com/NixOS/nixpkgs/commit/10d45b153467dfa152df8408c84e48cec255b942) | `` azure-cli-extensions.virtual-network-manager: 1.0.1 -> 1.2.0 ``            |
| [`9408854d`](https://github.com/NixOS/nixpkgs/commit/9408854d995ed39989ce5d420c70b6fc05305442) | `` azure-cli-extensions.traffic-collector: 0.1.2 -> 0.1.3 ``                  |
| [`f6ca30bb`](https://github.com/NixOS/nixpkgs/commit/f6ca30bb1cac6847748a82b613c9cf095575416b) | `` azure-cli-extensions.support: 1.0.4 -> 2.0.0 ``                            |
| [`9830a3b5`](https://github.com/NixOS/nixpkgs/commit/9830a3b515e5c4d119bf535b4d2502e3274614ab) | `` azure-cli-extensions.stack-hci-vm: 1.1.2 -> 1.1.11 ``                      |
| [`5491fbe8`](https://github.com/NixOS/nixpkgs/commit/5491fbe8b1906b9fd80b0b487412e543d23644ba) | `` azure-cli-extensions.spring: 1.21.0 -> 1.24.4 ``                           |
| [`3e4ddde3`](https://github.com/NixOS/nixpkgs/commit/3e4ddde3e49c861cfa49e6ea4fee27e6aaa9c158) | `` azure-cli-extensions.self-help: 0.3.0 -> 0.4.0 ``                          |
| [`2312e9a2`](https://github.com/NixOS/nixpkgs/commit/2312e9a251a5656e24f332016159e8525d30a85e) | `` azure-cli-extensions.nginx: 2.0.0b2 -> 2.0.0b4 ``                          |
| [`ae46a2c4`](https://github.com/NixOS/nixpkgs/commit/ae46a2c4612ce3d621b566c1151552b78fffd7bf) | `` azure-cli-extensions.monitor-control-service: 1.0.1 -> 1.0.2 ``            |
| [`394013ef`](https://github.com/NixOS/nixpkgs/commit/394013ef2f7f9c917b8a753a02657d2b1cb612a9) | `` azure-cli-extensions.managednetworkfabric: 6.0.0 -> 6.2.0 ``               |
| [`89a7e1d1`](https://github.com/NixOS/nixpkgs/commit/89a7e1d10649b971473c3514ee4775ccb323c290) | `` azure-cli-extensions.front-door: 1.0.17 -> 1.1.1 ``                        |
| [`a78ee30c`](https://github.com/NixOS/nixpkgs/commit/a78ee30c063b723ca15a97e8c718c601055f2a7c) | `` azure-cli-extensions.devcenter: 5.0.1 -> 6.0.1 ``                          |
| [`999a4fcd`](https://github.com/NixOS/nixpkgs/commit/999a4fcda5f5f4a6ba74959f6b9ae740c3e560e6) | `` azure-cli-extensions.dataprotection: 1.1.0 -> 1.5.0 ``                     |
| [`c9ef8d12`](https://github.com/NixOS/nixpkgs/commit/c9ef8d122ec9f4265d17a44f3511304099d699a8) | `` azure-cli-extensions.datafactory: 1.0.0 -> 1.0.2 ``                        |
| [`e351c136`](https://github.com/NixOS/nixpkgs/commit/e351c13604c4795a9c9a8506635dc258e5022aa7) | `` azure-cli-extensions.connectedvmware: 1.0.1 -> 1.1.0 ``                    |
| [`f78c340e`](https://github.com/NixOS/nixpkgs/commit/f78c340ec4a0dcd68d1d5187f624af32919d113c) | `` azure-cli-extensions.bastion: 0.3.0 -> 1.0.0 ``                            |
| [`7b680b8b`](https://github.com/NixOS/nixpkgs/commit/7b680b8bd249220d3e1b79e07816283a438d0fde) | `` azure-cli-extensions.apic-extension: 1.0.0b4 -> 1.0.0b5 ``                 |
| [`45b68d3d`](https://github.com/NixOS/nixpkgs/commit/45b68d3de29af7a094a4a7a5b4724e598c477c47) | `` azure-cli-extensions.amg: 1.3.2 -> 1.3.4 ``                                |
| [`18e4483f`](https://github.com/NixOS/nixpkgs/commit/18e4483fb6af0c1bd6d0ce13c4858d1308d0dab4) | `` azure-cli-extensions.aks-preview: 3.0.0b9 -> 5.0.0b1 ``                    |
| [`3f588c78`](https://github.com/NixOS/nixpkgs/commit/3f588c78c9704e2d34757bbdccdd3e67fc76d756) | `` azure-cli-extensions.storage-actions: init at 1.0.0b1 ``                   |
| [`abba411c`](https://github.com/NixOS/nixpkgs/commit/abba411c7b77b19578657a40cd816ac421cb6c42) | `` azure-cli-extensions.connectedmachine: 0.7.0 -> 1.0.0b1 ``                 |
| [`6d4215c8`](https://github.com/NixOS/nixpkgs/commit/6d4215c8f101daee004d88bdfc54018408d032c3) | `` python312Packages.bloodyad: 2.0.3 -> 2.0.4 ``                              |
| [`89882149`](https://github.com/NixOS/nixpkgs/commit/8988214905564cfe71390dd8e8a4f037a47eb606) | `` ldeep: 1.0.57 -> 1.0.58 ``                                                 |
| [`a2bfc205`](https://github.com/NixOS/nixpkgs/commit/a2bfc205245c07b474255cab9555da8f756e354a) | `` cfripper: 1.15.6 -> 1.15.7 ``                                              |
| [`f0151408`](https://github.com/NixOS/nixpkgs/commit/f0151408bcded8581e87c29cf9b7c8cdfbe9c354) | `` python312Packages.pycfmodel: 0.22.0 -> 1.0.0 ``                            |
| [`9baf3734`](https://github.com/NixOS/nixpkgs/commit/9baf3734650b3a5964fd7384296aa104ad5d950a) | `` python312Packages.tencentcloud-sdk-python: 3.0.1166 -> 3.0.1167 ``         |
| [`55023c9b`](https://github.com/NixOS/nixpkgs/commit/55023c9bdf6f439473534539d63ade6f00a5fdcd) | `` zsh-you-should-use: 1.7.4 -> 1.8.0 ``                                      |
| [`6ac84649`](https://github.com/NixOS/nixpkgs/commit/6ac84649bb5262c9907670712abf88a43bf76dca) | `` xdg-desktop-portal-xapp: 1.0.5 -> 1.0.6 ``                                 |
| [`fddfea5d`](https://github.com/NixOS/nixpkgs/commit/fddfea5ddb1de36dc6236895d841aac2998f0c35) | `` xdg-terminal-exec: 0.9.3 -> 0.10.0 ``                                      |
| [`aeb477d0`](https://github.com/NixOS/nixpkgs/commit/aeb477d0881fcd105694552f8664bc61abde02ac) | `` python311Packages.bandit: 1.7.8 -> 1.7.9 ``                                |
| [`f1f5d46e`](https://github.com/NixOS/nixpkgs/commit/f1f5d46e64e0d521ef0b9adcab05f5572cf41f59) | `` mpv-unwrapped: format with nixfmt rfc style ``                             |
| [`51d66a42`](https://github.com/NixOS/nixpkgs/commit/51d66a42c56de10d9a10b507fbc7b05f16ff164a) | `` mpv-unwrapped: fix build on x86_64-darwin ``                               |
| [`1da9f3e5`](https://github.com/NixOS/nixpkgs/commit/1da9f3e571bac0c1df209d7d2ba4d2122812b976) | `` pest-ide-tools: 0.3.9 -> 0.3.11 ``                                         |
| [`5e4fd0a2`](https://github.com/NixOS/nixpkgs/commit/5e4fd0a2a241359dff7caaeb361f85c097781967) | `` feishin: upgrade electron to v30 ``                                        |
| [`a55ed3b7`](https://github.com/NixOS/nixpkgs/commit/a55ed3b7cbc4a60814144a5d285812b05590ceb0) | `` ytt: 0.49.0 -> 0.49.1 ``                                                   |
| [`bcae94e2`](https://github.com/NixOS/nixpkgs/commit/bcae94e2a4da2fdf8e17eee6fe9663fd23735b80) | `` vendir: 0.40.1 -> 0.40.2 ``                                                |
| [`136cf7b8`](https://github.com/NixOS/nixpkgs/commit/136cf7b8b557c198cfa4f736e84e03a936565cfe) | `` squawk: 0.29.0 -> 1.0.0 ``                                                 |
| [`815ebd3b`](https://github.com/NixOS/nixpkgs/commit/815ebd3b750b2e6b5fec527e53c98d04b81f473b) | `` quorum: 24.4.0 -> 24.4.1 ``                                                |
| [`377053a7`](https://github.com/NixOS/nixpkgs/commit/377053a7161cc92b1e4dc889747c7171e9502514) | `` python311Packages.openai: 1.33.0 -> 1.34.0 ``                              |
| [`8b99f45d`](https://github.com/NixOS/nixpkgs/commit/8b99f45d2b1dabd795d4e1112abe666716dda66f) | `` bitwarden-desktop: 2024.5.0 -> 2024.6.0 ``                                 |
| [`d62d9430`](https://github.com/NixOS/nixpkgs/commit/d62d9430420e2869398217c001eb15fa587ef9c4) | `` bitwarden-desktop: enforce using correct Node version ``                   |
| [`e7521ac9`](https://github.com/NixOS/nixpkgs/commit/e7521ac9e28344e073080b443a9c76687d5d4d0e) | `` bitwarden-desktop: minor cleanup ``                                        |
| [`6d01be69`](https://github.com/NixOS/nixpkgs/commit/6d01be69bca49674cc4e47d2f327956d4fab4e08) | `` home-assistant-custom-lovelace-modules.android-tv-card: 3.7.4 -> 3.8.0 ``  |
| [`ce6d9343`](https://github.com/NixOS/nixpkgs/commit/ce6d9343b2be61d95d10a538c1a1ac9d9c9e86fb) | `` kubernetes-helm: 3.15.1 -> 3.15.2 ``                                       |
| [`fbd3ffea`](https://github.com/NixOS/nixpkgs/commit/fbd3ffea25781de260b69844ba037614a43e1551) | `` kubectl-cnpg: 1.23.1 -> 1.23.2 ``                                          |
| [`4f12f9c4`](https://github.com/NixOS/nixpkgs/commit/4f12f9c47928d4537449cc840a02966db219e637) | `` python311Packages.mitmproxy: 10.3.0 -> 10.3.1 ``                           |
| [`15a41bab`](https://github.com/NixOS/nixpkgs/commit/15a41bab91db642daa87efef7f3902cff1eb4510) | `` python311Packages.datasette: 0.64.6 -> 0.64.7 ``                           |
| [`107bfb25`](https://github.com/NixOS/nixpkgs/commit/107bfb2530f9d7adfc92e8ca5857303b5707e907) | `` function-runner: 5.0.0 -> 5.1.0 ``                                         |
| [`0a85b82a`](https://github.com/NixOS/nixpkgs/commit/0a85b82a63aef2636f4c3f2ffeb9c48ac9b5cd0d) | `` kapp: 0.62.0 -> 0.62.1 ``                                                  |
| [`15b78c32`](https://github.com/NixOS/nixpkgs/commit/15b78c32bf2258a9f09b1e92ef6fd20a19c0b4ba) | `` rclip: 1.8.10 -> 1.9.0 ``                                                  |
| [`cfc6c9b6`](https://github.com/NixOS/nixpkgs/commit/cfc6c9b6e433009a3f5c0a4c9cab526e09bd760a) | `` lib.trivial.importJSON: add example ``                                     |
| [`64f0f7a4`](https://github.com/NixOS/nixpkgs/commit/64f0f7a448ae743b7393a150bdc47553ea75b66c) | `` lib.trivial.importTOML: add example ``                                     |
| [`8e6f76d7`](https://github.com/NixOS/nixpkgs/commit/8e6f76d74d0a323ae86affe50059095f2d0e0cf9) | `` extism-cli: 1.5.0 -> 1.5.1 ``                                              |
| [`3fb0e045`](https://github.com/NixOS/nixpkgs/commit/3fb0e045a5e6f944d77733bf55e0f68f4ea84942) | `` nixos/wstunnel: adopt rust new cli flags ``                                |
| [`d1025803`](https://github.com/NixOS/nixpkgs/commit/d1025803acb9f60ed5eb6f173827266c4626c13d) | `` editorconfig-core-c: 0.12.7 -> 0.12.8 ``                                   |
| [`d251913b`](https://github.com/NixOS/nixpkgs/commit/d251913babbfde7d9bd9643fd49a8b65be2b4a2d) | `` cpm-cmake: 0.39.0 -> 0.40.0 ``                                             |
| [`862effdd`](https://github.com/NixOS/nixpkgs/commit/862effdd138712d18dececfbe414bb778cc0b5aa) | `` cargo-mobile2: 0.12.1 -> 0.12.2 ``                                         |
| [`d276229c`](https://github.com/NixOS/nixpkgs/commit/d276229c5345057410b9fe71f94520c3c2c83bc0) | `` python311Packages.uiprotect: 0.13.0 -> 1.1.0 ``                            |
| [`7edb5e00`](https://github.com/NixOS/nixpkgs/commit/7edb5e004163bbcceefaec868ba10f38846e588d) | `` roddhjav-apparmor-rules: 0-unstable-2024-06-11 -> 0-unstable-2024-06-12 `` |
| [`5723eefe`](https://github.com/NixOS/nixpkgs/commit/5723eefe6cec6e6f93d5a474c5d851bdadd23085) | `` eigenmath: 3.26-unstable-2024-06-03 -> 3.26-unstable-2024-06-09 ``         |
| [`5e57e65c`](https://github.com/NixOS/nixpkgs/commit/5e57e65ce4295a22fa7c36cf99e5233586773383) | `` python312Packages.libknot: 3.3.5 -> 3.3.6 ``                               |
| [`082d9691`](https://github.com/NixOS/nixpkgs/commit/082d9691752395733b93820e2acdff32424cddb0) | `` twitch-tui: 2.6.10 -> 2.6.11 ``                                            |
| [`d784ed9d`](https://github.com/NixOS/nixpkgs/commit/d784ed9dfa976336181966d03b6c8bd461b04eca) | `` open-in-mpv: 2.2.1 -> 2.2.2 ``                                             |
| [`d4b6df0d`](https://github.com/NixOS/nixpkgs/commit/d4b6df0d24e15787cb8eb258826e7958504f034f) | `` sentry-native: 0.7.5 -> 0.7.6 ``                                           |
| [`a2395a2e`](https://github.com/NixOS/nixpkgs/commit/a2395a2e722fb106c1ea977dd2aef84fc0699dc2) | `` magnetico: fix build ``                                                    |
| [`1a19d3af`](https://github.com/NixOS/nixpkgs/commit/1a19d3af33b7185173263748d23b6a08207e8f9d) | `` evcc: 0.126.5 -> 0.127.0 ``                                                |