### PR TITLE
chore(flake/nixpkgs): `a71e967e` -> `b2852eb9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719075281,
-        "narHash": "sha256-CyyxvOwFf12I91PBWz43iGT1kjsf5oi6ax7CrvaMyAo=",
+        "lastModified": 1719506693,
+        "narHash": "sha256-C8e9S7RzshSdHB7L+v9I51af1gDM5unhJ2xO1ywxNH8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a71e967ef3694799d0c418c98332f7ff4cc5f6af",
+        "rev": "b2852eb9365c6de48ffb0dc2c9562591f652242a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`90995582`](https://github.com/NixOS/nixpkgs/commit/909955825b3a2d0ccf080b8030b9459f41e0fc29) | `` emacsPackages.rime: fix build error in darwin (#322873) ``                |
| [`3d530bea`](https://github.com/NixOS/nixpkgs/commit/3d530bea8d981894aa996162efe7de9d75a32cc9) | `` btrfs-progs: 6.9.1 -> 6.9.2 ``                                            |
| [`f6c43dab`](https://github.com/NixOS/nixpkgs/commit/f6c43dab739c8bcce80577c80cefeaea031c7a4f) | `` linux-rt_6_6: 6.6.34-rt33 -> 6.6.35-rt34 ``                               |
| [`660b0f45`](https://github.com/NixOS/nixpkgs/commit/660b0f4554497f7fc79b3a25a694327cd8800a8b) | `` linux-rt_6_1: 6.1.94-rt33 -> 6.1.95-rt34 ``                               |
| [`afcbbf9e`](https://github.com/NixOS/nixpkgs/commit/afcbbf9e95f9b91f77a6dd5eb999e68bdea4f089) | `` linux_6_1: 6.1.95 -> 6.1.96 ``                                            |
| [`5f53abdb`](https://github.com/NixOS/nixpkgs/commit/5f53abdb3f1f043371786891d0d54c1577cce07f) | `` linux_6_6: 6.6.35 -> 6.6.36 ``                                            |
| [`acca00bf`](https://github.com/NixOS/nixpkgs/commit/acca00bf2c0eccf9a7153cf9140eb972a3bc9054) | `` linux_6_9: 6.9.6 -> 6.9.7 ``                                              |
| [`07f6b665`](https://github.com/NixOS/nixpkgs/commit/07f6b665d1be6192f776fd878fce758544a77976) | `` linux_testing: 6.10-rc4 -> 6.10-rc5 ``                                    |
| [`9f9b501f`](https://github.com/NixOS/nixpkgs/commit/9f9b501fe9a92c568c5e816cc7ff903ea20e3181) | `` qt6.qtmqtt: 6.7.1 -> 6.7.2 ``                                             |
| [`833cadb7`](https://github.com/NixOS/nixpkgs/commit/833cadb7503c36b1a7067e3420c2d554096f8ec6) | `` qt6: 6.7.1 -> 6.7.2 ``                                                    |
| [`100ae3ed`](https://github.com/NixOS/nixpkgs/commit/100ae3ed65dd88b37f23f549d2c6536d79347678) | `` python311Packages.pytelegrambotapi: 4.19.0 -> 4.20.0 ``                   |
| [`0c40909b`](https://github.com/NixOS/nixpkgs/commit/0c40909b96fe78422775c86fdf47dc5545a2e728) | `` python311Packages.neo4j: 5.21.0 -> 5.22.0 ``                              |
| [`7cd57254`](https://github.com/NixOS/nixpkgs/commit/7cd57254405fecbee03e4be3721c7ae05ae3c2e1) | `` python311Packages.llama-index-graph-stores-neo4j: 0.2.5 -> 0.2.6 ``       |
| [`2c480654`](https://github.com/NixOS/nixpkgs/commit/2c480654815767f988d4dd5706448447762c826a) | `` python312Packages.influxdb-client: 1.43.0 -> 1.44.0 ``                    |
| [`418e9bdf`](https://github.com/NixOS/nixpkgs/commit/418e9bdf39b9c245d05f425f5efc009abe5b6c54) | `` rubyfmt: mark as broken on aarch64-darwin ``                              |
| [`d527d75f`](https://github.com/NixOS/nixpkgs/commit/d527d75f15a17a72d024a7077deb2c55ec86353d) | `` python312Packages.google-cloud-monitoring: 2.21.0 -> 2.22.0 ``            |
| [`3df418ce`](https://github.com/NixOS/nixpkgs/commit/3df418cedbb251c33b97304339397bd8d2761382) | `` python312Packages.google-cloud-bigquery: 3.24.0 -> 3.25.0 ``              |
| [`a9ee57f5`](https://github.com/NixOS/nixpkgs/commit/a9ee57f51280af9906a99d01f4901a6f652e4191) | `` python312Packages.google-cloud-pubsub: 2.21.4 -> 2.21.5 ``                |
| [`0215ebf7`](https://github.com/NixOS/nixpkgs/commit/0215ebf7d92d7372a83bddd64c09e0b68248f7e7) | `` exploitdb: 2024-06-15 -> 2024-06-27 ``                                    |
| [`dfe067d1`](https://github.com/NixOS/nixpkgs/commit/dfe067d1d81f60e3f602dd76710c1a70c41803e6) | `` asnmap: 1.1.0 -> 1.1.1 ``                                                 |
| [`0c3b659e`](https://github.com/NixOS/nixpkgs/commit/0c3b659e7709d760d52496076b26041c1e5706ea) | `` python3Packages.xformers: fix building with cudaSupport ``                |
| [`58519c15`](https://github.com/NixOS/nixpkgs/commit/58519c15eb960041b71b8222980a901e150c40f3) | `` rubyfmt: avoid failing upon warning (#322233) ``                          |
| [`68dd5e6f`](https://github.com/NixOS/nixpkgs/commit/68dd5e6f5ec826547dfe4c2e8e3266b76332891f) | `` stripe-cli: 1.19.5 -> 1.21.0 ``                                           |
| [`f5be5c23`](https://github.com/NixOS/nixpkgs/commit/f5be5c2324d112717c7aabe2919f482183154914) | `` zed-editor: 0.137.6 -> 0.141.2 ``                                         |
| [`144ac0d7`](https://github.com/NixOS/nixpkgs/commit/144ac0d7fc16609847d957d53a715d393caaeef2) | `` nixVersions: bump patch releases ``                                       |
| [`bbdfbf0b`](https://github.com/NixOS/nixpkgs/commit/bbdfbf0b86c41ab0935024dcbe737fb7e0f8f212) | `` trufflehog: 3.78.2 -> 3.79.0 ``                                           |
| [`0bf599d2`](https://github.com/NixOS/nixpkgs/commit/0bf599d2460763bbdd7d6aab249ce77306b20ebe) | `` python311Packages.pyftpdlib: 1.5.9 -> 1.5.10 ``                           |
| [`2076935e`](https://github.com/NixOS/nixpkgs/commit/2076935e3db98f46c6c77a33fc2ad9966cf35097) | `` scion-apps: init at unstable-2024-04-05 ``                                |
| [`23c24527`](https://github.com/NixOS/nixpkgs/commit/23c24527dc69f286a2588de99d04edfe2f354bfe) | `` nixos/scion: add scion package when scion.enable = true ``                |
| [`973108d3`](https://github.com/NixOS/nixpkgs/commit/973108d3ed65520c19c7b4d96897d61af2c658e1) | `` nixos/scion: use recursiveUpdate instead of // ``                         |
| [`541a298c`](https://github.com/NixOS/nixpkgs/commit/541a298cd8e50687b3e4a6e7698fbab413923f65) | `` sc-im: fix build on Darwin ``                                             |
| [`642adc7a`](https://github.com/NixOS/nixpkgs/commit/642adc7a5d1c45f61c52af8ae88936a1144a6875) | `` python311Packages.lightning-utilities: 0.11.2 -> 0.11.3.post0 ``          |
| [`b96214f3`](https://github.com/NixOS/nixpkgs/commit/b96214f3c46c6267dff860e3f0e6b23bc6f2914b) | `` python312Packages.dvc-s3: 3.1.0 -> 3.2.0 ``                               |
| [`611d3754`](https://github.com/NixOS/nixpkgs/commit/611d3754d28dadaf1e716121901bdde4606dd4cb) | `` python312Packages.authheaders: refactor ``                                |
| [`5d267851`](https://github.com/NixOS/nixpkgs/commit/5d2678517ac7cc804e78198bfce1584f223e09d0) | `` python312Packages.authheaders: 0.16.2 -> 0.16.3 ``                        |
| [`72f0a028`](https://github.com/NixOS/nixpkgs/commit/72f0a0288ddff0380d4fabb1d5e541e166a0744e) | `` python312Packages.anova-wifi: 0.13.0 -> 0.14.0 ``                         |
| [`0cdbfe30`](https://github.com/NixOS/nixpkgs/commit/0cdbfe30b5eb6537383b582b518af533b2cee4d6) | `` mosdns: init at 5.3.1 ``                                                  |
| [`87cd4369`](https://github.com/NixOS/nixpkgs/commit/87cd4369d4762ab7ceb1e5ed92e0570850828424) | `` fennel-ls: 0.1.2 -> 0.1.3 ``                                              |
| [`f9eda5a2`](https://github.com/NixOS/nixpkgs/commit/f9eda5a2cfdb9e6e83898d1f269b4a7bb4f10c23) | `` copier: 9.1.0 -> 9.2.0 ``                                                 |
| [`a2782b76`](https://github.com/NixOS/nixpkgs/commit/a2782b76af82c5c1120bfeb8a4af054ed8009a9e) | `` pgraphs: 0.6.12 -> 0.6.13 ``                                              |
| [`8b96fcbd`](https://github.com/NixOS/nixpkgs/commit/8b96fcbd954803b0b8155d069b2b69c8ac47ae9e) | `` canard: init at 0.0.2-unstable-2024-04-22 ``                              |
| [`5f169536`](https://github.com/NixOS/nixpkgs/commit/5f1695360314c235d03beef8642b2f367863f6e0) | `` python312Packages.aiogram: 3.7.0 -> 3.8.0 ``                              |
| [`c05e2f7d`](https://github.com/NixOS/nixpkgs/commit/c05e2f7d8397094282112f6e08062b3c4971e997) | `` python312Packages.aiodhcpwatcher: 1.0.1 -> 1.0.2 ``                       |
| [`7af983c4`](https://github.com/NixOS/nixpkgs/commit/7af983c4a10f541edc6836fbfb4faa29a9d4d46c) | `` python312Packages.adguardhome: refactor ``                                |
| [`7bdd2ba1`](https://github.com/NixOS/nixpkgs/commit/7bdd2ba1367d4ebe4a1379e64140e8a48b58b293) | `` python312Packages.adguardhome: 0.6.3 -> 0.7.0 ``                          |
| [`897a01e0`](https://github.com/NixOS/nixpkgs/commit/897a01e0e7cea90e4f650c2e8ed3249f6888e721) | `` python312Packages.aiohttp-zlib-ng: 0.3.1 -> 0.3.2 ``                      |
| [`da4d200d`](https://github.com/NixOS/nixpkgs/commit/da4d200d0d7f00348b5379cb06a31d48acf6253a) | `` ggshield: 1.28.0 -> 1.29.0 ``                                             |
| [`3cec93f1`](https://github.com/NixOS/nixpkgs/commit/3cec93f1900c64d7587498308afe388b1ad6e005) | `` poutine: 0.12.0 -> 0.13.0 ``                                              |
| [`d0372143`](https://github.com/NixOS/nixpkgs/commit/d0372143212463b990365d927ca137fa9f598317) | `` python312Packages.google-generativeai: 0.7.0 -> 0.7.1 ``                  |
| [`43ae47d8`](https://github.com/NixOS/nixpkgs/commit/43ae47d832b33002f235c59da2195a84d1d7e1ec) | `` python312Packages.jsonargparse: 4.30.0 -> 4.31.0 ``                       |
| [`6ab94a6c`](https://github.com/NixOS/nixpkgs/commit/6ab94a6c633f69952a66b2bb6d88988be65b376e) | `` checkov: 3.2.145 -> 3.2.148 ``                                            |
| [`73bd3121`](https://github.com/NixOS/nixpkgs/commit/73bd31216242bde1c5e3ccf7f9b4a104eb408363) | `` checkov: 3.2.144 -> 3.2.145 ``                                            |
| [`db05e701`](https://github.com/NixOS/nixpkgs/commit/db05e7015fcbbf8ec869b905a40e4a252da05efb) | `` python312Packages.botocore-stubs: 1.34.132 -> 1.34.134 ``                 |
| [`7d567963`](https://github.com/NixOS/nixpkgs/commit/7d56796335df280362452f97091b4af652a15829) | `` python312Packages.boto3-stubs: 1.34.133 -> 1.34.134 ``                    |
| [`7be97576`](https://github.com/NixOS/nixpkgs/commit/7be97576c21580b91237c9a2d9a176e0d17eebb2) | `` python312Packages.tencentcloud-sdk-python: 3.0.1176 -> 3.0.1177 ``        |
| [`2dbfc381`](https://github.com/NixOS/nixpkgs/commit/2dbfc3818a9ac4d1bacfd2d39d83d7b9eb7dd1d8) | `` python312Packages.discovery30303: refactor ``                             |
| [`52271836`](https://github.com/NixOS/nixpkgs/commit/52271836425efeeeea9cce13bd568e63e90aaa8d) | `` deepin.dpa-ext-gnomekeyring: Remove libgnome-keyring dependency ``        |
| [`6a50fdfe`](https://github.com/NixOS/nixpkgs/commit/6a50fdfeff1d42178d0d788e30c13c01148125a1) | `` mongodb-compass: move to pkgs/by-name ``                                  |
| [`8d01e011`](https://github.com/NixOS/nixpkgs/commit/8d01e011e14ee6bd9b54cef0409656bac88c38fb) | `` mongodb-compass: remove `meta = with lib;` ``                             |
| [`5649f06d`](https://github.com/NixOS/nixpkgs/commit/5649f06dfc3c98c49ecbbc4fb466443f90ad3e89) | `` mongodb-compass: format with nixfmt ``                                    |
| [`4f89a5f1`](https://github.com/NixOS/nixpkgs/commit/4f89a5f1ff73bb6cb195f8806393b4d08c1f690f) | `` mongodb-compass: 1.43.0 -> 1.43.2 ``                                      |
| [`04092971`](https://github.com/NixOS/nixpkgs/commit/04092971d9a66136f04c8b220251e5fce1f279f2) | `` resources: 1.4.0 -> 1.5.0 ``                                              |
| [`da3789ad`](https://github.com/NixOS/nixpkgs/commit/da3789ad1b11306062dbc0df76d29d97fb4bd6fe) | `` llvmPackages: 17.0.6 -> 18.1.5 on other platforms ``                      |
| [`9ce12446`](https://github.com/NixOS/nixpkgs/commit/9ce12446c17f3fcb25c7caa29ae7b8779a944eb3) | `` docker-compose: 2.27.2 -> 2.28.1 ``                                       |
| [`4553926f`](https://github.com/NixOS/nixpkgs/commit/4553926f17e9a9622e0475091bdddb5e6a5503e3) | `` boulder: 2022-09-29 -> 2024-06-17a ``                                     |
| [`90e35645`](https://github.com/NixOS/nixpkgs/commit/90e35645fc623215e9b5a0dca87a0e1aa8b5643f) | `` coqPackages.coq-hammer: init at 1.3.2 ``                                  |
| [`b8a048b9`](https://github.com/NixOS/nixpkgs/commit/b8a048b959ed4c675a8934e23470d6e42ef422ba) | `` coqPackages.coq-hammer-tactics: init at 1.3.2 ``                          |
| [`ef3b7254`](https://github.com/NixOS/nixpkgs/commit/ef3b725431fd14539f3095ceac7925b50dd150ef) | `` flyctl: 0.2.72 -> 0.2.75 ``                                               |
| [`e643fd5b`](https://github.com/NixOS/nixpkgs/commit/e643fd5bba6df6dd78dd88dd9133fdc529a26dad) | `` eza: 0.18.19 -> 0.18.20 ``                                                |
| [`560cd874`](https://github.com/NixOS/nixpkgs/commit/560cd874a37396968aea0bd9abc54fb1122424b7) | `` nixos/etc: fix using etc overlay on cross-compiled systems ``             |
| [`9114d521`](https://github.com/NixOS/nixpkgs/commit/9114d5216ee42b1d3b886d4b065476d0716c72cc) | `` nmap-formatter: 3.0.0 -> 3.0.1 ``                                         |
| [`9053895f`](https://github.com/NixOS/nixpkgs/commit/9053895fce049b249cbcc1c749a2bd386422a77c) | `` slurm: 23.11.7.1 -> 24.05.0.1 ``                                          |
| [`05b67b87`](https://github.com/NixOS/nixpkgs/commit/05b67b87b72d6b4d56fa330e5e21cf3f12f2f081) | `` nixos/quickwit: fix service ReadWritePaths ``                             |
| [`e0e5cc67`](https://github.com/NixOS/nixpkgs/commit/e0e5cc6711870b0bb70114a861f53c74351095ba) | `` cargo-tally: 1.0.46 -> 1.0.47 ``                                          |
| [`ce591cce`](https://github.com/NixOS/nixpkgs/commit/ce591ccedf73010a2b50d6432cef5fdf75753823) | `` copilot-cli: 1.33.4 -> 1.34.0 ``                                          |
| [`46c14105`](https://github.com/NixOS/nixpkgs/commit/46c14105621bccfc867ffbcb13d0226afe47b97d) | `` codeowners: 1.1.2 -> 1.2.1 ``                                             |
| [`7677e0f7`](https://github.com/NixOS/nixpkgs/commit/7677e0f78e196495629e83bb0cd5cc6d4cd585af) | `` openscad: fix lib3mf linking ``                                           |
| [`b5c9f563`](https://github.com/NixOS/nixpkgs/commit/b5c9f563f3a4fa107feb47079a8534b60dcfad9c) | `` wgautomesh: 0.1.0 -> unstable-20240524 (#321524) ``                       |
| [`2579e137`](https://github.com/NixOS/nixpkgs/commit/2579e1379d1f941e976935a7285fbcaa2b8e4766) | `` maintainers: update matrix user id of networkException ``                 |
| [`07f6955b`](https://github.com/NixOS/nixpkgs/commit/07f6955b94b846227d67eb33cf458c6db30fac02) | `` python3Packages.torch: fix tests.*.gpuCheck ``                            |
| [`a630861e`](https://github.com/NixOS/nixpkgs/commit/a630861eb547efc267621e3bc7cdaf08aa7dec82) | `` kitty-themes: 0-unstable-2024-06-12 -> 0-unstable-2024-06-26 ``           |
| [`c6b2bffd`](https://github.com/NixOS/nixpkgs/commit/c6b2bffd35c7843f5f1ead3857ec851d8dc95515) | `` kubescape: Unbreak for darwin ``                                          |
| [`02b69a56`](https://github.com/NixOS/nixpkgs/commit/02b69a56cbd1f594746e3927531fd9ae68bedfb1) | `` rar2fs: switch to unrar 7 ``                                              |
| [`760dbdba`](https://github.com/NixOS/nixpkgs/commit/760dbdba67b47550850eb9f7cdb8e3b73257fc9b) | `` python311Packages.awkward-cpp: 2.6.5 -> 2.6.6 ``                          |
| [`06ab0426`](https://github.com/NixOS/nixpkgs/commit/06ab0426599bb2bce44a361e90d918eb82d34c8a) | `` python311Packages.awkward: 2.6.5 -> 2.6.6 ``                              |
| [`cb59bc06`](https://github.com/NixOS/nixpkgs/commit/cb59bc06e95e4c259212611bcaa960e4a81adca7) | `` python311Packages.rioxarray: 0.15.5 -> 0.15.7 ``                          |
| [`08c21134`](https://github.com/NixOS/nixpkgs/commit/08c21134cdf4852f251a71bac0b859f9e3237ba2) | `` pandoc: apply patch removing the usage of polyfill.io in the templates `` |
| [`ab7cf5d2`](https://github.com/NixOS/nixpkgs/commit/ab7cf5d23c90ee5b83444e0a80a606688d278ecd) | `` wireplumber: 0.5.3 -> 0.5.4 ``                                            |
| [`b4cffe17`](https://github.com/NixOS/nixpkgs/commit/b4cffe178c94f0e2b6d293a2d3333f701144c27e) | `` lib.meta: refactor to use doc-comments (#313589) ``                       |
| [`4a48dece`](https://github.com/NixOS/nixpkgs/commit/4a48decea2d0190cf7e3f502dd4326dcb55fc88d) | `` cppcheck: 2.14.1 -> 2.14.2 ``                                             |
| [`cf7a400d`](https://github.com/NixOS/nixpkgs/commit/cf7a400d313a32a8ffc635f87b7fc665d5c46640) | `` cppcheck: reformat ``                                                     |
| [`6b36d738`](https://github.com/NixOS/nixpkgs/commit/6b36d738857991a96d3eb5f7530450fff90acefa) | `` cppcheck: move to `pkgs/by-name` ``                                       |
| [`b5af504a`](https://github.com/NixOS/nixpkgs/commit/b5af504a3d7ccc519d224beed840b98478e340e8) | `` doc: migrate lib.filesystem to doc-comment format (#312222) ``            |
| [`521521de`](https://github.com/NixOS/nixpkgs/commit/521521def13bf10920574184820081e6a9c027c5) | `` mprocs: 0.6.4 -> 0.7.0 ``                                                 |
| [`0aff8c5e`](https://github.com/NixOS/nixpkgs/commit/0aff8c5ede72dd45f16303b4ef702520d3f9dbe6) | `` handlr-regex: 0.10.0 -> 0.10.1 ``                                         |
| [`666c37f0`](https://github.com/NixOS/nixpkgs/commit/666c37f04dbe9677b12461140b7949e1e5886368) | `` libliftoff: fix changelog link ``                                         |
| [`a676f125`](https://github.com/NixOS/nixpkgs/commit/a676f12533a4c39d4ea4525807c99beee331d139) | `` libliftoff: 0.4.1 -> 0.5.0 ``                                             |
| [`6881edcd`](https://github.com/NixOS/nixpkgs/commit/6881edcd733cc9a8b7f827c57bf525b87650aa6e) | `` libliftoff: refactor into versioned package ``                            |
| [`b84d3a46`](https://github.com/NixOS/nixpkgs/commit/b84d3a46c12419efc9c7be65b670129b87dac42d) | `` semodule-utils: 3.6 -> 3.7 ``                                             |