### PR TITLE
chore(flake/nixpkgs): `7e7c39ea` -> `693bc46d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720768451,
-        "narHash": "sha256-EYekUHJE2gxeo2pM/zM9Wlqw1Uw2XTJXOSAO79ksc4Y=",
+        "lastModified": 1720957393,
+        "narHash": "sha256-oedh2RwpjEa+TNxhg5Je9Ch6d3W1NKi7DbRO1ziHemA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7e7c39ea35c5cdd002cd4588b03a3fb9ece6fad9",
+        "rev": "693bc46d169f5af9c992095736e82c3488bf7dbb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                          |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`bdf5d0a3`](https://github.com/NixOS/nixpkgs/commit/bdf5d0a3be9b2aaecbc586ba34a46012cc35f2bd) | `` numad: 0.5 -> 0.5-unstable-2023-09-06 (#315168) ``                                            |
| [`a828d5e0`](https://github.com/NixOS/nixpkgs/commit/a828d5e0780120d37d5be6255b0e0dde8321b966) | `` sequoia-sqop: 0.34.0 -> 0.35.0 ``                                                             |
| [`87d8dc97`](https://github.com/NixOS/nixpkgs/commit/87d8dc97a967a6abeea741b6ecfad17ce76e0b5b) | `` eksctl: 0.184.0 -> 0.186.0 ``                                                                 |
| [`a9e1eaef`](https://github.com/NixOS/nixpkgs/commit/a9e1eaefc9cd2096f8bb20f40144296313dc9b4a) | `` python312Packages.ytmusicapi: 1.7.4 -> 1.7.5 ``                                               |
| [`3470a1b2`](https://github.com/NixOS/nixpkgs/commit/3470a1b29a99012103d7b9f400496359fe174eb2) | `` electrum{,-grs,-ltc}: drop tlslite-ng dependency ``                                           |
| [`23b35621`](https://github.com/NixOS/nixpkgs/commit/23b3562191981c75d7d38050dc0373f9ff03a45c) | `` dub: 1.38.0 -> 1.38.1 ``                                                                      |
| [`0f20077d`](https://github.com/NixOS/nixpkgs/commit/0f20077d2819cae2efe8ad71d027b6eec0f21404) | `` balena-cli: 18.2.17 -> 18.2.29 ``                                                             |
| [`f90841a7`](https://github.com/NixOS/nixpkgs/commit/f90841a7003432abc8cd27700461b8e910b65610) | `` sticky-notes: init at 0.2.5 ``                                                                |
| [`42c8f494`](https://github.com/NixOS/nixpkgs/commit/42c8f494efcc082b15ef83e5cf40dbbf5ed84a03) | `` python312Packages.uiprotect: 5.2.0 -> 5.2.2 ``                                                |
| [`512e8afd`](https://github.com/NixOS/nixpkgs/commit/512e8afdb96591aacbe155974c92fb40d317d6af) | `` treewide: remove unused occurence of stdenv (and other) arguments ``                          |
| [`0a1370d3`](https://github.com/NixOS/nixpkgs/commit/0a1370d338361d35253dcc28cfe7b8f6112e405b) | `` vscode: 1.91.0 -> 1.91.1 ``                                                                   |
| [`cf80bd78`](https://github.com/NixOS/nixpkgs/commit/cf80bd7819d5dd80a3bcf5daa7803b0f9f28c749) | `` mkvtoolnix: 85.0 -> 86.0 ``                                                                   |
| [`88d05be4`](https://github.com/NixOS/nixpkgs/commit/88d05be4a28ccad961faef5f85859882cbf7e5a2) | `` shpool: 0.6.2 -> 0.6.3 ``                                                                     |
| [`e03e7e18`](https://github.com/NixOS/nixpkgs/commit/e03e7e1826e236be0f0bea0f6a7555aba6d2d886) | `` wavemon: 0.9.5 -> 0.9.6 ``                                                                    |
| [`13144909`](https://github.com/NixOS/nixpkgs/commit/13144909978b8f2186bccd89470d519697830c5a) | `` icoextract: add missing -t to install command ``                                              |
| [`6dbc8417`](https://github.com/NixOS/nixpkgs/commit/6dbc841749e5eb09c2bff2afeb422f6938d05c48) | `` tart: 2.12.0 -> 2.13.0 ``                                                                     |
| [`4942776d`](https://github.com/NixOS/nixpkgs/commit/4942776d7523130e2c3bd46e69515115eb839fb5) | `` nixVersions.nix_2_23: 2.23.2 -> 2.23.3 ``                                                     |
| [`62cac25e`](https://github.com/NixOS/nixpkgs/commit/62cac25eeef6d6ec97d48e8d6c581f32c6016c5c) | `` python312Packages.unstructured: 0.14.8 -> 0.14.10 ``                                          |
| [`2f9ffba1`](https://github.com/NixOS/nixpkgs/commit/2f9ffba13a45f3b8cd9b35d51fa1c79cc91e6ce3) | `` lxd-ui: 0.10 -> 0.11 ``                                                                       |
| [`ccbdc8d4`](https://github.com/NixOS/nixpkgs/commit/ccbdc8d4093fbec72149f1d84ddb4f94bbe16d70) | `` flyctl: 0.2.79 -> 0.2.88 ``                                                                   |
| [`76069daf`](https://github.com/NixOS/nixpkgs/commit/76069dafc9c020a9bead5e6858f0fe791e04d068) | `` clever-tools: missing argument for autocomplete scripts (#326039) ``                          |
| [`6985c126`](https://github.com/NixOS/nixpkgs/commit/6985c126266e360608f5dd0c5aade5a439e0013e) | `` syncthingtray: 1.5.4 -> 1.5.5 ``                                                              |
| [`369eafd4`](https://github.com/NixOS/nixpkgs/commit/369eafd4fe21d1a3e285390f4ef1ac9dd62c1ee7) | `` python311Packages.angr: 9.2.109 -> 9.2.110 ``                                                 |
| [`de6db9d8`](https://github.com/NixOS/nixpkgs/commit/de6db9d8f9d39a384e175762256c240834757d8f) | `` python312Packages.cle: 9.2.109 -> 9.2.110 ``                                                  |
| [`ed45ad62`](https://github.com/NixOS/nixpkgs/commit/ed45ad62c1ee4958470cb422fc8c4a3a664da7c4) | `` python312Packages.claripy: 9.2.109 -> 9.2.110 ``                                              |
| [`98e9d9df`](https://github.com/NixOS/nixpkgs/commit/98e9d9dfd6f84445923315500f7d867a5bb20533) | `` python312Packages.pyvex: 9.2.109 -> 9.2.110 ``                                                |
| [`9adb3d76`](https://github.com/NixOS/nixpkgs/commit/9adb3d769a913dbadd879abbda77f73e6e541cfd) | `` python312Packages.ailment: 9.2.109 -> 9.2.110 ``                                              |
| [`a8b78a50`](https://github.com/NixOS/nixpkgs/commit/a8b78a50e9fb1f16c6c34d1bbe354d42f1b6fb29) | `` python312Packages.archinfo: 9.2.109 -> 9.2.110 ``                                             |
| [`e7d14c7f`](https://github.com/NixOS/nixpkgs/commit/e7d14c7f0dff5b8b94bb43a053e25a4b6bb9f0cc) | `` python312Packages.aiolifx: 1.0.4 -> 1.0.5 ``                                                  |
| [`d474282f`](https://github.com/NixOS/nixpkgs/commit/d474282faf0a0a0ade1f2e0b943b2d42440caae0) | `` python312Packages.aioraven: 0.6.0 -> 0.7.0 ``                                                 |
| [`689310ec`](https://github.com/NixOS/nixpkgs/commit/689310ec502db3f5e96a15e912c93656ba1a0d8c) | `` python312Packages.env-canada: 0.7.1 -> 0.7.2 ``                                               |
| [`2e5241a3`](https://github.com/NixOS/nixpkgs/commit/2e5241a3a25daa4e2f1d576ca4fc9ebfd3c56690) | `` python312Packages.pynetbox: 7.3.3 -> 7.3.4 ``                                                 |
| [`66651a7b`](https://github.com/NixOS/nixpkgs/commit/66651a7bb131afd9a10c36723f4da29963d89bb0) | `` aws-sam-cli: 1.119.0 -> 1.120.0 ``                                                            |
| [`acbd2ad6`](https://github.com/NixOS/nixpkgs/commit/acbd2ad67d06aa97d75e5ec0c34efc568a01c337) | `` python312Packages.botocore-stubs: 1.34.140 -> 1.34.144 ``                                     |
| [`0f4e1545`](https://github.com/NixOS/nixpkgs/commit/0f4e1545bcfe70281c2675d02f96a4649fdb6960) | `` python312Packages.boto3-stubs: 1.34.140 -> 1.34.144 ``                                        |
| [`cdad47b9`](https://github.com/NixOS/nixpkgs/commit/cdad47b9eca34f7f5acbd83d5f86ecad26d25fc3) | `` python313FreeThreading: init ``                                                               |
| [`691c17ab`](https://github.com/NixOS/nixpkgs/commit/691c17abc8832305961e6bc39a0fe8c26f162114) | `` nuclei-templates: 9.9.0 -> 9.9.1 ``                                                           |
| [`8d2ecf9e`](https://github.com/NixOS/nixpkgs/commit/8d2ecf9e25605ff1ac0c5d7ee66be7c6cd443040) | `` zmusic: 1.1.12 -> 1.1.13 ``                                                                   |
| [`06b0cb22`](https://github.com/NixOS/nixpkgs/commit/06b0cb2248eb35c211bb6bbad717f4c0e4b0039d) | `` Revert "nc4nix: 0-unstable-2024-03-01 -> 0-unstable-2024-05-24; nextcloudPackages: update" `` |
| [`06b93088`](https://github.com/NixOS/nixpkgs/commit/06b93088f4b50bfb4e8746027f4566bf2509a976) | `` google-cloud-sdk: fish completions ``                                                         |
| [`c84b739d`](https://github.com/NixOS/nixpkgs/commit/c84b739d75879132106d342c68496a7e2d9b8e82) | `` mousam: 1.3.1 -> 1.3.2 ``                                                                     |
| [`4210454c`](https://github.com/NixOS/nixpkgs/commit/4210454cfcaf592cf9206874f6772b1c7939ea00) | `` terragrunt: 0.59.6 -> 0.62.0 ``                                                               |
| [`15af9a3c`](https://github.com/NixOS/nixpkgs/commit/15af9a3c1b193b8983ddced330835a0bafbb70be) | `` grafana-alloy: 1.2.0 -> 1.2.1 ``                                                              |
| [`3ff51e1b`](https://github.com/NixOS/nixpkgs/commit/3ff51e1bb2c86cf7c48b724c6e715097366eabd4) | `` electron: fix update script ``                                                                |
| [`64d80302`](https://github.com/NixOS/nixpkgs/commit/64d803029fed15d042f48922c10b488dbedf9fc8) | `` gamescope: patch gamescopereaper path ``                                                      |
| [`671f0eb0`](https://github.com/NixOS/nixpkgs/commit/671f0eb01fcd08293216b7a9a16cafeaa618afcc) | `` stalwart-mail: Enable tests ``                                                                |
| [`e589ce61`](https://github.com/NixOS/nixpkgs/commit/e589ce61481b872e668c5b9c43fde5933416c10a) | `` ringing-lib: init at 0-unstable-2024-05-31 (#210560) ``                                       |
| [`b7954b47`](https://github.com/NixOS/nixpkgs/commit/b7954b47d12eccb2b8f4e02cbccf11c0e48fdb8b) | `` username-anarchy: init at 0.5 ``                                                              |
| [`e16fee18`](https://github.com/NixOS/nixpkgs/commit/e16fee18572ea6933b0f39354f40bde98603d821) | `` linuxKernel/rtl8812au: update driver source for kernel 6.7+ (#326863) ``                      |
| [`6fd80c0c`](https://github.com/NixOS/nixpkgs/commit/6fd80c0cce0d431ddeec708b72c41839417e447e) | `` bepasty: fix overriding hash ``                                                               |
| [`07c1bc20`](https://github.com/NixOS/nixpkgs/commit/07c1bc203404a2c34188131b4e454185eba23b11) | `` treewide: sha256 -> hash attribute for pypi fetchers ``                                       |
| [`75c2a866`](https://github.com/NixOS/nixpkgs/commit/75c2a866c5670516e43db2099889cc3de08ddc42) | `` gamescope: 3.14.23 -> 3.14.24 ``                                                              |
| [`05f5dbd4`](https://github.com/NixOS/nixpkgs/commit/05f5dbd470d5f9c9c6f53fca395ceb1bf20f404e) | `` doc/php: Fix mkComposerRepository example ``                                                  |
| [`fccf7e02`](https://github.com/NixOS/nixpkgs/commit/fccf7e0219234c2f40056a52ead4632c67369258) | `` python312Packages.optimum: 1.20.0 -> 1.21.2 ``                                                |
| [`22376a52`](https://github.com/NixOS/nixpkgs/commit/22376a52fc5b2580f95016896c66b25eacce5916) | `` python312Packages.clarifai: 10.5.2 -> 10.5.4 ``                                               |
| [`3eae2208`](https://github.com/NixOS/nixpkgs/commit/3eae220883d4c134f924a338a9fd963b6bb5d21f) | `` asm-lsp: 0.6.0 -> 0.7.1 ``                                                                    |
| [`cb41d0ac`](https://github.com/NixOS/nixpkgs/commit/cb41d0ac1adf2df992c7e2ffa751babc4fe5f0fc) | `` woodpecker-plugin-git: 2.5.0 -> 2.5.1 ``                                                      |
| [`07ded82f`](https://github.com/NixOS/nixpkgs/commit/07ded82f798105cf6693af1db968a3463a7f5e9e) | `` sqldef: 0.17.11 -> 0.17.13 ``                                                                 |
| [`3ff9a9c6`](https://github.com/NixOS/nixpkgs/commit/3ff9a9c612b0029928093bdeb0636d45c5527032) | `` python312Packages.pymorphy3: 2.0.1 -> 2.0.2 ``                                                |
| [`ce3dd652`](https://github.com/NixOS/nixpkgs/commit/ce3dd652234318508da37f8cbc7d69ace7b098ef) | `` openshift: 4.14 -> 4.16 ``                                                                    |
| [`9a097c2e`](https://github.com/NixOS/nixpkgs/commit/9a097c2e4ee60862b07fd7cc8f0fbb67a93d60ce) | `` python311Packages.gerbonara: 1.2.0 -> 1.4.0 (#326208) ``                                      |
| [`69adf156`](https://github.com/NixOS/nixpkgs/commit/69adf156ef737e283e04ed675ee52bd27c7e660d) | `` common-updater-scripts: Fix u-s-v updating npmDeps ``                                         |
| [`9fc19b08`](https://github.com/NixOS/nixpkgs/commit/9fc19b086689e9b1c0a031e5faf841b454468d64) | `` maintainers/scripts/update.py: Fix worktree cleanup on failure ``                             |
| [`3c78e0ce`](https://github.com/NixOS/nixpkgs/commit/3c78e0ce042ee74dc75375dfd9199d4194511fb6) | `` _experimental-update-script-combinators.sequence: Terminate on failure ``                     |
| [`9ecab00b`](https://github.com/NixOS/nixpkgs/commit/9ecab00bf4b35e98403824ce542524e64f15de0b) | `` ocaml-ng.ocamlPackages{_5_1,}.merlin: fix vim python-3.12 warnings ``                         |
| [`9a67fa73`](https://github.com/NixOS/nixpkgs/commit/9a67fa73056ef245852e5a21c733861480ee530e) | `` python312Packages.zigpy-znp: 0.12.2 -> 0.12.3 ``                                              |
| [`6bf8475e`](https://github.com/NixOS/nixpkgs/commit/6bf8475e7621c38fa7fe176c2e32c432ece3fec9) | `` python312Packages.lifelines: 0.28.0 -> 0.29.0 ``                                              |
| [`52f30bac`](https://github.com/NixOS/nixpkgs/commit/52f30bac311a0ce5b782578c540f09073383a7d2) | `` marksman: allow local networking in darwin sandbox ``                                         |
| [`86db49c7`](https://github.com/NixOS/nixpkgs/commit/86db49c704f90416caf07fe8778ac1ab11e673a3) | `` beatsabermodmanager: add dotnet 6.0.31 packages ``                                            |
| [`39f4bf2e`](https://github.com/NixOS/nixpkgs/commit/39f4bf2ef563999e302819f24c776fdc9a084428) | `` fsautocomplete: use dotnetCorePackages.sdk_8_0 ``                                             |
| [`10ec0560`](https://github.com/NixOS/nixpkgs/commit/10ec0560137c7c77d4dcf044835c9ae997a09241) | `` dotnet: 6.0.31 -> 6.0.32 ``                                                                   |
| [`9a87d1b6`](https://github.com/NixOS/nixpkgs/commit/9a87d1b6de6e18e473953ac533c7ebefe382bf35) | `` dotnet: 9.0.0-preview.5 -> 9.0.0-preview.6 ``                                                 |
| [`6fbc6257`](https://github.com/NixOS/nixpkgs/commit/6fbc62574ce5f3092a7525c642b3648dc56f8318) | `` dotnet: 8.0.6 -> 8.0.7 ``                                                                     |
| [`b729601a`](https://github.com/NixOS/nixpkgs/commit/b729601a9e6c459fd8884dea513af143111bed54) | `` r2modman: 3.1.48 -> 3.1.49 ``                                                                 |
| [`2e440f5b`](https://github.com/NixOS/nixpkgs/commit/2e440f5b87df886b6de1769b12cb51bcfa1accba) | `` qpwgraph: 0.7.4 -> 0.7.5 ``                                                                   |
| [`b5cd8f55`](https://github.com/NixOS/nixpkgs/commit/b5cd8f55e530fc2cf4af6fe2703220a421545b69) | `` plasmusic-toolbar: 1.2.2 -> 1.3.0 ``                                                          |
| [`50206e8a`](https://github.com/NixOS/nixpkgs/commit/50206e8a66994a97bb274e3bc4591178f62caa11) | `` python312Packages.beanhub-import: 0.3.2 -> 0.3.4 ``                                           |
| [`08601cfe`](https://github.com/NixOS/nixpkgs/commit/08601cfede5d1b28fb8c72d73fa0774d4e6f36c9) | `` python312Packages.pydyf: 0.10.0 -> 0.11.0 ``                                                  |
| [`cce8e5df`](https://github.com/NixOS/nixpkgs/commit/cce8e5df8959d57a8fa63180eb0c88d29b9e83cf) | `` zenity: 4.0.1 → 4.0.2 ``                                                                      |
| [`6bb3ac98`](https://github.com/NixOS/nixpkgs/commit/6bb3ac98ccf67e28c5e86991f23920d088ab3307) | `` docs: $TMP -> $TMPDIR in Darwin build ``                                                      |
| [`4f6a9e06`](https://github.com/NixOS/nixpkgs/commit/4f6a9e0673163e96cfcd02f0e64b3ff0c5425679) | `` speedtest-go: 1.7.7 -> 1.7.8 ``                                                               |
| [`5d27ab8d`](https://github.com/NixOS/nixpkgs/commit/5d27ab8df13638ce24ea29076c70d4c3be9ab165) | `` lazygit: 0.42.0 -> 0.43.1 ``                                                                  |
| [`4c01c9d8`](https://github.com/NixOS/nixpkgs/commit/4c01c9d8a59e37140913dae78d6d49b8a85b21b7) | `` sved: fix the wrapper to be a python script ``                                                |
| [`444dcf38`](https://github.com/NixOS/nixpkgs/commit/444dcf383b6136db1f44be520a3038001e0bc65a) | `` cloudcompare: fix source hash ``                                                              |
| [`d875ba94`](https://github.com/NixOS/nixpkgs/commit/d875ba9428169477bb1c42af0fd276959cadf3c1) | `` helmfile-wrapped: 0.165.0 -> 0.166.0 ``                                                       |
| [`67eedad2`](https://github.com/NixOS/nixpkgs/commit/67eedad208441a3517713f75500bec58ad302fc4) | `` ntpd-rs: 1.1.3 -> 1.2.0 ``                                                                    |
| [`3eeff547`](https://github.com/NixOS/nixpkgs/commit/3eeff54780a1a8c73c82ca51987962b62bd4219e) | `` nixos/alsa: kill sound.enable and friends with fire ``                                        |
| [`f33c833e`](https://github.com/NixOS/nixpkgs/commit/f33c833e35d9d0b92d9255ec7bcb7832f84c961f) | `` python312Packages.monai: 1.3.1 -> 1.3.2 ``                                                    |
| [`452a2137`](https://github.com/NixOS/nixpkgs/commit/452a2137e0e33173e87e2bba01af8394ca8f68b1) | `` principia: 2024.06.28 -> 2024.07.12 ``                                                        |
| [`cea3c9fb`](https://github.com/NixOS/nixpkgs/commit/cea3c9fbe57bf03d06283b88816bbad1fd8f7266) | `` SDL2_image_2_6: migrate to by-name ``                                                         |
| [`108d3799`](https://github.com/NixOS/nixpkgs/commit/108d37991f17054f036a6fffb3d113828081a0d6) | `` SDL2_image_2_0: migrate to by-name ``                                                         |
| [`a91743a5`](https://github.com/NixOS/nixpkgs/commit/a91743a5f3a667aa6987c86c58466e2712143246) | `` SDL2_image: remove cpages from meta.maintainers ``                                            |
| [`1f8f3e7c`](https://github.com/NixOS/nixpkgs/commit/1f8f3e7c402d85ee6737d0ec5ff498873232354e) | `` SDL2_image: nixfmt ``                                                                         |
| [`7f084a85`](https://github.com/NixOS/nixpkgs/commit/7f084a8532ffb264473b5f4bb3c3fd51efce5060) | `` SDL2_image: set strictDeps as true ``                                                         |
| [`093e3b60`](https://github.com/NixOS/nixpkgs/commit/093e3b60d33223529d32b8865a08e61a7e573b35) | `` SDL2_image: refactor ``                                                                       |
| [`c3fa9d6d`](https://github.com/NixOS/nixpkgs/commit/c3fa9d6d0bff5c19cb733226f2f9d6a9b536299a) | `` SDL2_image: migrate to by-name ``                                                             |
| [`ac745676`](https://github.com/NixOS/nixpkgs/commit/ac7456760d6d2cb19deb2a1fd22753235cb0893b) | `` python312Packages.azure-mgmt-cosmosdb: 9.5.0 -> 9.5.1 ``                                      |
| [`8f64cb67`](https://github.com/NixOS/nixpkgs/commit/8f64cb671de9ba675605a250dde7051da0aa1647) | `` qlog: 0.37.0 -> 0.37.1 ``                                                                     |
| [`1763b8ac`](https://github.com/NixOS/nixpkgs/commit/1763b8acbd4d19da2b0bf21ef8d8c13d3499bd53) | `` chainsaw: 2.9.1-2 -> 2.9.2 ``                                                                 |
| [`64bfb6cb`](https://github.com/NixOS/nixpkgs/commit/64bfb6cb175667e5b91cd0cec8154ff4839de967) | `` dbmate: 2.18.0 -> 2.19.0 ``                                                                   |
| [`69ee28dc`](https://github.com/NixOS/nixpkgs/commit/69ee28dc951fcfc9a63360254998d4e14caa083d) | `` kdePackages.francis: fix build, deduplicate ``                                                |
| [`5db5c530`](https://github.com/NixOS/nixpkgs/commit/5db5c530d93bebd3c974fd339a1b0462b04bb156) | `` ab-av1: 0.7.15 -> 0.7.16 ``                                                                   |
| [`08455005`](https://github.com/NixOS/nixpkgs/commit/084550058fbcfc3619c79762100fe0e0153be00f) | `` python312Packages.duckduckgo-search: 6.1.9 -> 6.1.12 ``                                       |
| [`e6536644`](https://github.com/NixOS/nixpkgs/commit/e6536644e359e0fc8bfbf6cff80d78833c7e42ef) | `` python312Packages.meilisearch: 0.31.3 -> 0.31.4 ``                                            |
| [`45e75109`](https://github.com/NixOS/nixpkgs/commit/45e75109dc779466a07e587aa0e628068ddc491e) | `` lastfm: init at 2.1.39 ``                                                                     |
| [`157e8174`](https://github.com/NixOS/nixpkgs/commit/157e817428e6e8616259712dc76beeac5b45e63f) | `` neocmakelsp: 0.7.7 -> 0.7.8 ``                                                                |