### PR TITLE
chore(flake/rust-overlay): `c3e21712` -> `0b2b2da1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1721269159,
-        "narHash": "sha256-eHrGuKZKQb762qdCkrfoyyxXLKumYhiXJca1ig0RftE=",
+        "lastModified": 1721528458,
+        "narHash": "sha256-uruH/EV8Rpa/CRxn8CiMzhoA6tJe8qO5c8NdgP1g0rM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c3e217122ac55680606d69bc693bdf262f14f602",
+        "rev": "0b2b2da1dad1c675c45d9e23c75674de969de83b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                |
| ----------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0b2b2da1`](https://github.com/oxalica/rust-overlay/commit/0b2b2da1dad1c675c45d9e23c75674de969de83b) | `` manifest: update `` |
| [`b7996075`](https://github.com/oxalica/rust-overlay/commit/b7996075da11a2d441cfbf4e77c2939ce51506fd) | `` manifest: update `` |
| [`d5bc7b1b`](https://github.com/oxalica/rust-overlay/commit/d5bc7b1b21cf937fb8ff108ae006f6776bdb163d) | `` manifest: update `` |