### PR TITLE
chore(flake/nixpkgs): `ad0b5eed` -> `1d9c2c9b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1721138476,
-        "narHash": "sha256-+W5eZOhhemLQxelojLxETfbFbc19NWawsXBlapYpqIA=",
+        "lastModified": 1721379653,
+        "narHash": "sha256-8MUgifkJ7lkZs3u99UDZMB4kbOxvMEXQZ31FO3SopZ0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ad0b5eed1b6031efaed382844806550c3dcb4206",
+        "rev": "1d9c2c9b3e71b9ee663d11c5d298727dace8d374",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`7a5ca794`](https://github.com/NixOS/nixpkgs/commit/7a5ca794793b2bc07c1af429f6688d66c9e39607) | `` warzone2100: 4.4.2 -> 4.5.1 ``                                                     |
| [`e89db63f`](https://github.com/NixOS/nixpkgs/commit/e89db63f958f8e1c3a908628ede2adcf9666fe4a) | `` z3_4_8_5: fix by using Python 3.11 ``                                              |
| [`0539bbe0`](https://github.com/NixOS/nixpkgs/commit/0539bbe086ef7ed0bf23412a777b3239c9ed8270) | `` nixos/tests: Fix tests failing with new default IPv6 configuration ``              |
| [`6492fda3`](https://github.com/NixOS/nixpkgs/commit/6492fda37a4e02c2693f5ed7707ab7abfe8c8ee2) | `` boulder: 2024-07-02 -> 2024-07-16 ``                                               |
| [`852e8184`](https://github.com/NixOS/nixpkgs/commit/852e81841534a404b8af8fbdee8abe1bf480393a) | `` python312Packages.fakeredis: 2.23.2 -> 2.23.3 ``                                   |
| [`adf2eb40`](https://github.com/NixOS/nixpkgs/commit/adf2eb40620db802f576290cb4288ef464598da3) | `` woodpecker-server: 2.6.0 -> 2.7.0 ``                                               |
| [`8def5f86`](https://github.com/NixOS/nixpkgs/commit/8def5f86a1dae649f81992feb18d4fec68251181) | `` python312Packages.plexapi: 4.15.14 -> 4.15.15 ``                                   |
| [`6745ba7c`](https://github.com/NixOS/nixpkgs/commit/6745ba7c461757cd9a2797a725209ba81f612597) | `` python312Packages.peewee: 3.17.5 -> 3.17.6 ``                                      |
| [`2dc47672`](https://github.com/NixOS/nixpkgs/commit/2dc47672f6c55de8b92b8491f6bf95092a44286c) | `` gitu: 0.22.1 -> 0.23.0 ``                                                          |
| [`46cf8c5d`](https://github.com/NixOS/nixpkgs/commit/46cf8c5ddba8bb499556477f1361ef2fd962eec0) | `` python312Packages.cvelib: 1.4.0 -> 1.5.0 ``                                        |
| [`fe3dabff`](https://github.com/NixOS/nixpkgs/commit/fe3dabff7fd53dc39e2b39249c9d266cf0a90684) | `` apache-jena: 5.0.0 -> 5.1.0 ``                                                     |
| [`3bd8794a`](https://github.com/NixOS/nixpkgs/commit/3bd8794a5954faafee6e85e748d74d3372917cb2) | `` homepage-dashboard: 0.9.3 -> 0.9.5 ``                                              |
| [`be9599e3`](https://github.com/NixOS/nixpkgs/commit/be9599e3d4a4b271b19f6da3501522503f6c9cfe) | `` nixos/scion: introduce package option (#327765) ``                                 |
| [`283920fe`](https://github.com/NixOS/nixpkgs/commit/283920fe4efa5571693d40a337c4769994262cdf) | `` cinnamon.mint-y-icons: 1.7.6 -> 1.7.7 ``                                           |
| [`849ea8df`](https://github.com/NixOS/nixpkgs/commit/849ea8df2712382a1abf16172f577045b697cde1) | `` cinnamon.mint-x-icons: 1.7.0 -> 1.7.1 ``                                           |
| [`62c1bfd8`](https://github.com/NixOS/nixpkgs/commit/62c1bfd8e68682476dff1e264e80ae3a103ef928) | `` mcdreforged: 2.13.0 -> 2.13.1 ``                                                   |
| [`1a291889`](https://github.com/NixOS/nixpkgs/commit/1a291889418c0e2932a118bd88fe45b0288fbb54) | `` emacsPackages.ligo-mode: 1.7.1-unstable-2024-06-28 -> 1.7.1-unstable-2024-07-17 `` |
| [`614804b8`](https://github.com/NixOS/nixpkgs/commit/614804b827aaf694290fb7fc31653c2f9a77b3e5) | `` mysql84: 8.4.0 -> 8.4.1 ``                                                         |
| [`2fbd7993`](https://github.com/NixOS/nixpkgs/commit/2fbd7993f3aa412a2f5c8817ae253c7245e6aac1) | `` flashmq: 1.15.3 -> 1.15.4 ``                                                       |
| [`6abbe725`](https://github.com/NixOS/nixpkgs/commit/6abbe725ca156244c38efff05be12b33bef5097d) | `` nixos/etc: handle mountpoints on top of /etc when switching ``                     |
| [`6b716214`](https://github.com/NixOS/nixpkgs/commit/6b71621423d9430b4b23ca9d37668859f0ab2dd5) | `` move-mount-beneath: fix build on aarch64 ``                                        |
| [`dc3525a2`](https://github.com/NixOS/nixpkgs/commit/dc3525a2416cca43a08d22f40518f1c996c607a6) | `` whistle: 2.9.77 -> 2.9.78 ``                                                       |
| [`bb040bd4`](https://github.com/NixOS/nixpkgs/commit/bb040bd44177773ce0c566b951b54da8a29899a2) | `` yanic: 1.6.1 -> 1.6.2 ``                                                           |
| [`b6e354f0`](https://github.com/NixOS/nixpkgs/commit/b6e354f052a79bec05432acec5f4810c1239b05f) | `` nixos/qemu-vm: remove creation of /etc/nixos ``                                    |
| [`cb5a876e`](https://github.com/NixOS/nixpkgs/commit/cb5a876e8243a6f09ad9883fe5db58f1f9a80b74) | `` nixos/qemu-vm: consistently use efiSysMountPoint ``                                |
| [`b7b90d04`](https://github.com/NixOS/nixpkgs/commit/b7b90d04551c5dd2fd99b924bc0bde860a4cb72f) | `` nixos/qemu-vm: fsck ESP ``                                                         |
| [`0e5f9298`](https://github.com/NixOS/nixpkgs/commit/0e5f92985160e5a9064861882179b6d4878f2220) | `` nixos/tests/qemu-vm-store: init ``                                                 |
| [`ded6d983`](https://github.com/NixOS/nixpkgs/commit/ded6d983d69cde4eadbfdc2d4725953464b0850c) | `` nixos/qemu-vm: use new overlayfs API ``                                            |
| [`54674e90`](https://github.com/NixOS/nixpkgs/commit/54674e9063317a41b498b40ce856614bd5b7050f) | `` nixos/qemu-vm: remove duplication between scripted and systemd initrd ``           |
| [`bb24a96d`](https://github.com/NixOS/nixpkgs/commit/bb24a96dbf410160e999f85cdbef42127ad832c0) | `` bpf-linker: 0.9.5 -> 0.9.12 ``                                                     |
| [`3c2052bd`](https://github.com/NixOS/nixpkgs/commit/3c2052bd2006e5a718df0a8e6193b72dc654012d) | `` verilator: 5.022 -> 5.026 ``                                                       |
| [`8bd07206`](https://github.com/NixOS/nixpkgs/commit/8bd0720626bca025c84f72c7b30ee1bd379e28a1) | `` verilator: format with nixfmt ``                                                   |
| [`98966676`](https://github.com/NixOS/nixpkgs/commit/989666769f5635f965851e654d77e26ca6144224) | `` bcachefs-tools: add version-test and mainProgram ``                                |
| [`7f997e8d`](https://github.com/NixOS/nixpkgs/commit/7f997e8da142cf670276286d7600b6f59be01604) | `` redpanda-client: 24.1.9 -> 24.1.10 ``                                              |
| [`6caafcba`](https://github.com/NixOS/nixpkgs/commit/6caafcba3bdccda8cf32eeef91a23d323b42c797) | `` bcachefs-tools: add fish,bash,zsh completions ``                                   |
| [`f8b1e28e`](https://github.com/NixOS/nixpkgs/commit/f8b1e28e3d70bbb327fa26b5f574f75c970cc983) | `` python312Packages.msgraph-core: 1.1.1 -> 1.1.2 ``                                  |
| [`d63b3b2f`](https://github.com/NixOS/nixpkgs/commit/d63b3b2fafa0597ad1c840409bbd84a053936bc0) | `` python313: 3.13.0b3 -> 3.13.0b4 ``                                                 |
| [`bfaf3fee`](https://github.com/NixOS/nixpkgs/commit/bfaf3fee8a9678f00b698ab6c08481ccfec56748) | `` python312Packages.yolink-api: 0.4.4 -> 0.4.5 ``                                    |
| [`d35d3d12`](https://github.com/NixOS/nixpkgs/commit/d35d3d12961185ebbb774ac347b2a230c48f1590) | `` raylib: fix missing sound ``                                                       |
| [`1439ca5d`](https://github.com/NixOS/nixpkgs/commit/1439ca5df9d1907c79f60389f4c246b17454fa6a) | `` python312Packages.trio-asyncio: 0.14.1 -> 0.15.0 ``                                |
| [`67c2c105`](https://github.com/NixOS/nixpkgs/commit/67c2c1057b4e016b638008701334fdf266353139) | `` python312Packages.python-rapidjson: 1.16 -> 1.18 ``                                |
| [`34094f77`](https://github.com/NixOS/nixpkgs/commit/34094f77da49e765bfa514d5e881b93d5a7c231e) | `` containerd: 1.7.19 -> 1.7.20 ``                                                    |
| [`27708e5e`](https://github.com/NixOS/nixpkgs/commit/27708e5e0d5b0cefd5d2a1d7a137f690e5f56ab3) | `` python311Packages.python-lsp-ruff: clean package ``                                |
| [`eedce364`](https://github.com/NixOS/nixpkgs/commit/eedce364ccdc149a477e6f3b9f061b665a43811f) | `` python311Packages.python-lsp-black: clean package ``                               |
| [`96d860cf`](https://github.com/NixOS/nixpkgs/commit/96d860cf3f55eea1525e9bdb9d0defb0df7b3786) | `` python311Packages.pyls-memestra: clean package ``                                  |
| [`cd01f0fd`](https://github.com/NixOS/nixpkgs/commit/cd01f0fd9859be2b98624bdcfaca302d4e653a73) | `` python311Packages.pylsp-rope: clean package ``                                     |
| [`4a4c5ac1`](https://github.com/NixOS/nixpkgs/commit/4a4c5ac18c5cd8bd329798638ff576b17787ba7b) | `` python311Packages.python-lsp-black: clean package ``                               |
| [`3c205d48`](https://github.com/NixOS/nixpkgs/commit/3c205d4838245b5cc4135bd62c63512983847b0c) | `` python311Packages.pyls-isort: clean package ``                                     |
| [`676a51c4`](https://github.com/NixOS/nixpkgs/commit/676a51c41fc8e31284af292bea19d6189d5cf017) | `` nixos/hardware.display: init ``                                                    |
| [`8559b460`](https://github.com/NixOS/nixpkgs/commit/8559b460b1caf1b619ef25ef9bb251cfa8282db9) | `` edido: init ``                                                                     |
| [`eb6459a2`](https://github.com/NixOS/nixpkgs/commit/eb6459a233c5a3217244f0e911edc708364559b1) | `` linuxhw-edid-fetcher: init at unstable-2023-05-08 ``                               |
| [`7c3815ab`](https://github.com/NixOS/nixpkgs/commit/7c3815ab71cf6819c0aefb7eba4b4f2be2e85997) | `` kernel: fix EDID firmware loading ``                                               |
| [`4ede20cc`](https://github.com/NixOS/nixpkgs/commit/4ede20cc6fd9faae98c7d207525d1e3ba7e2bdcc) | `` makeModulesClosure: include /lib/firmware/edid ``                                  |
| [`8e1b9b9e`](https://github.com/NixOS/nixpkgs/commit/8e1b9b9eb38108a7eac6d683a2121fc9134eb0f7) | `` ci/pinned-nixpkgs.json: update ``                                                  |
| [`545eb50c`](https://github.com/NixOS/nixpkgs/commit/545eb50c7df9973afebdfdeac350481bf6eeb81e) | `` ci/update-pinned-nixpkgs.sh: Allow setting the rev ``                              |
| [`ad66fdb8`](https://github.com/NixOS/nixpkgs/commit/ad66fdb844883bd9516e926ed71d57741c073366) | `` Revert "python3Packages.tuya-device-sharing-sdk: 0.1.9 -> 0.2.0" ``                |
| [`8fe47000`](https://github.com/NixOS/nixpkgs/commit/8fe470008141f100c45774525f90ed55a7bbbb96) | `` linux_latest-libre: 19607 -> 19611 ``                                              |
| [`d811812d`](https://github.com/NixOS/nixpkgs/commit/d811812da47f2ff38be08cd26e1a2331180cc20d) | `` linux-rt_6_6: 6.6.36-rt35 -> 6.6.40-rt36 ``                                        |
| [`23f15041`](https://github.com/NixOS/nixpkgs/commit/23f15041a284e227e2f817dd46788bdb3f0468a6) | `` linux-rt_6_1: 6.1.96-rt35 -> 6.1.99-rt36 ``                                        |
| [`9ae9eb99`](https://github.com/NixOS/nixpkgs/commit/9ae9eb99b385d8a3e22d64ec21cdc982544fea4a) | `` goflow2: 2.1.3 -> 2.1.5 ``                                                         |
| [`fe97c4d5`](https://github.com/NixOS/nixpkgs/commit/fe97c4d5c5f70876842be6064959a298b8766b1a) | `` linux_4_19: 4.19.317 -> 4.19.318 ``                                                |
| [`9bc41634`](https://github.com/NixOS/nixpkgs/commit/9bc4163423e86b7420029e20b3b47a869d905caf) | `` linux_5_4: 5.4.279 -> 5.4.280 ``                                                   |
| [`967bd016`](https://github.com/NixOS/nixpkgs/commit/967bd016088a10a11dcba4978a39ebf6d8349eb7) | `` linux_5_10: 5.10.221 -> 5.10.222 ``                                                |
| [`1964afd6`](https://github.com/NixOS/nixpkgs/commit/1964afd6dce21657c5af55d2f79d88acb3e12d73) | `` linux_5_15: 5.15.162 -> 5.15.163 ``                                                |
| [`b4a1a789`](https://github.com/NixOS/nixpkgs/commit/b4a1a789941c303672e6b1d2bca84fdb569c0b7e) | `` linux_6_1: 6.1.99 -> 6.1.100 ``                                                    |
| [`e9cc7e63`](https://github.com/NixOS/nixpkgs/commit/e9cc7e63377139a40b486927b737621622d241a5) | `` hashrat: 1.21 -> 1.22 ``                                                           |
| [`d63fd8f5`](https://github.com/NixOS/nixpkgs/commit/d63fd8f569695f65f8cd7f7247e2076a657618f4) | `` linux_6_6: 6.6.40 -> 6.6.41 ``                                                     |
| [`d2720312`](https://github.com/NixOS/nixpkgs/commit/d272031250d3c5a9f437711a34468f852bd1bcd1) | `` linux_6_9: 6.9.9 -> 6.9.10 ``                                                      |
| [`d8382f19`](https://github.com/NixOS/nixpkgs/commit/d8382f19e9834a1d19ed1f86a132994a262ba668) | `` er-patcher: 1.12-2 -> 1.12-3 ``                                                    |
| [`096fa66f`](https://github.com/NixOS/nixpkgs/commit/096fa66f0b84489e88ff5f2fefe03182f2c71ad3) | `` python312Packages.diff-cover: 9.1.0 -> 9.1.1 ``                                    |
| [`9d05f083`](https://github.com/NixOS/nixpkgs/commit/9d05f083f85ff090957613102eaac126868849f4) | `` python312Packages.grpcio-health-checking: 1.64.1 -> 1.65.1 ``                      |
| [`524b23e1`](https://github.com/NixOS/nixpkgs/commit/524b23e1d8e639082b061cfa8552234c5608b9e7) | `` python312Packages.grpcio-reflection: 1.64.1 -> 1.65.1 ``                           |
| [`6752817b`](https://github.com/NixOS/nixpkgs/commit/6752817bcbc587156b05119199db8902093dc724) | `` python312Packages.grpcio-channelz: 1.64.1 -> 1.65.1 ``                             |
| [`bd59cdfb`](https://github.com/NixOS/nixpkgs/commit/bd59cdfbf837d4e908390aca95aab199498d637b) | `` ttdl: 4.3.0 -> 4.4.0 ``                                                            |
| [`d73bf185`](https://github.com/NixOS/nixpkgs/commit/d73bf185b6239ac4306a40aa24358a2de0ddb298) | `` python312Packages.sievelib: 1.4.0 -> 1.4.1 ``                                      |
| [`e1e2481e`](https://github.com/NixOS/nixpkgs/commit/e1e2481e8ba27b86c92f290e953c27a830de761b) | `` ansible-lint: 24.2.2 -> 24.7.0 ``                                                  |
| [`33849e49`](https://github.com/NixOS/nixpkgs/commit/33849e49d7884ed0f2bff2ffab8e4915ba9e4ae4) | `` python312Packages.xknx: don't pin pytest-asyncio ``                                |
| [`703748f1`](https://github.com/NixOS/nixpkgs/commit/703748f1548f46087bf7822b05e06f59b7f93337) | `` switch-to-configuration-ng: fix link in README ``                                  |
| [`a1717b84`](https://github.com/NixOS/nixpkgs/commit/a1717b84563fcad9230c78e52618b06dd38f35ff) | `` uboot: 2024.04 -> 2024.07 ``                                                       |
| [`c2e1be3b`](https://github.com/NixOS/nixpkgs/commit/c2e1be3be00a40de14f58c5501b838c29a70e14e) | `` doc: fixup doc/build-helpers references ``                                         |
| [`e4a19185`](https://github.com/NixOS/nixpkgs/commit/e4a191852fe7a608a90bce970b618079fcda4d26) | `` python312Packages.sdds: 0.4.1 -> 0.4.2 ``                                          |
| [`322c5837`](https://github.com/NixOS/nixpkgs/commit/322c5837c32e68a040bb4ac6c5c87ed7f4b89feb) | `` osu-lazer: 2024.625.2 -> 2024.718.0 ``                                             |
| [`11dfdeae`](https://github.com/NixOS/nixpkgs/commit/11dfdeae6078c5d0f78f307373f0b7a8b18ca3b8) | `` osu-lazer-bin: 2024.625.2 -> 2024.718.0 ``                                         |
| [`c637407a`](https://github.com/NixOS/nixpkgs/commit/c637407a0bc468d25574ed8e3ca3a1d7aa7f9e98) | `` python312Packages.structlog: 24.1.0 -> 24.4.0 ``                                   |
| [`3c8f6db8`](https://github.com/NixOS/nixpkgs/commit/3c8f6db8161acb1542d4c58f020559ffacd4e2ac) | `` python312Packages.unasync: 0.5.0 -> 0.6.0 ``                                       |
| [`99a62683`](https://github.com/NixOS/nixpkgs/commit/99a6268316d69fdd0f2f1e239e1344491d1064ca) | `` python311Packages.pyhanko: 0.21.0 -> 0.25.1 ``                                     |
| [`878d821e`](https://github.com/NixOS/nixpkgs/commit/878d821e461170ea0a884f22f076399272ebd0af) | `` brainflow: Remove with lib ``                                                      |
| [`c7a83864`](https://github.com/NixOS/nixpkgs/commit/c7a83864624dd180cf487ecef723ae3bd38d5685) | `` python312Packages.bonsai: 1.5.2 -> 1.5.3 ``                                        |
| [`ff9b0b38`](https://github.com/NixOS/nixpkgs/commit/ff9b0b38bd239cea8208068223f01c5507199640) | `` tflint: 0.51.2 -> 0.52.0 ``                                                        |
| [`4944dda3`](https://github.com/NixOS/nixpkgs/commit/4944dda3207251944883374edac7ab4d426906e4) | `` decker: 1.45 -> 1.46 ``                                                            |
| [`a6aa3acc`](https://github.com/NixOS/nixpkgs/commit/a6aa3acc7305ba822ad4b4df1a9cd9bb1dbd7bb0) | `` vencord: 1.9.4 -> 1.9.5 ``                                                         |
| [`3ea481d4`](https://github.com/NixOS/nixpkgs/commit/3ea481d4ab8e45053b76d66bba96799f26edfaec) | `` Revert "bitwarden-cli: 2024.6.1 -> 2024.7.0" ``                                    |
| [`38ebef00`](https://github.com/NixOS/nixpkgs/commit/38ebef00d8b80370ccc5f1871f5dcc36ff025a90) | `` python311Packages.pylsp-mypy: clean package ``                                     |
| [`c6f6c282`](https://github.com/NixOS/nixpkgs/commit/c6f6c282181d5c6fb8f63d95738b97b09f25c945) | `` nixos/testing: Add ipv6 configuration ``                                           |
| [`6af07f66`](https://github.com/NixOS/nixpkgs/commit/6af07f66608ab150d96866686fa3892901f31bac) | `` authelia: postPatch openapi.yml ``                                                 |
| [`160d90cb`](https://github.com/NixOS/nixpkgs/commit/160d90cb91426de316bb5e0105f0b10500aadeac) | `` waybar: 0.10.3 -> 0.10.4 ``                                                        |
| [`0b5aa11e`](https://github.com/NixOS/nixpkgs/commit/0b5aa11e2bf839123320bf6dc52cd3e95bc79a9c) | `` metrics job: schedule on any machine, for now ``                                   |
| [`a9353ef3`](https://github.com/NixOS/nixpkgs/commit/a9353ef3ae1d2381156c8765d5b27a256457315f) | `` kubernetes-helmPlugins.helm-diff: 3.9.8 -> 3.9.9 ``                                |
| [`9619b75d`](https://github.com/NixOS/nixpkgs/commit/9619b75d0f0e613d521b1c1230e6bd19f7edcd05) | `` mqtt-explorer: init at 0.4.0-beta.6 ``                                             |
| [`dd09495f`](https://github.com/NixOS/nixpkgs/commit/dd09495f645fbb840c9e6e3cbec838358b847b42) | `` lib/licenses: add cc-by-nd-40 ``                                                   |
| [`32ce7bf5`](https://github.com/NixOS/nixpkgs/commit/32ce7bf5ded4c6d08c3c4359268c3638f1268c95) | `` handheld-daemon: 3.1.1 -> 3.2.1 ``                                                 |
| [`9e00a656`](https://github.com/NixOS/nixpkgs/commit/9e00a6563b1729a0261a5fe7280c789abca524c4) | `` miriway: 0-unstable-2024-06-13 -> 0-unstable-2024-07-17 ``                         |
| [`85ee393d`](https://github.com/NixOS/nixpkgs/commit/85ee393d4c52e3ca9657ba21e4919028db54ccbd) | `` gitkraken: 10.1.0 -> 10.1.1 ``                                                     |
| [`da3465f7`](https://github.com/NixOS/nixpkgs/commit/da3465f7f575be2340838b2063be0f615492b32b) | `` opentelemetry-cpp: 1.13.0 -> 1.16.0 ``                                             |
| [`dceec6d7`](https://github.com/NixOS/nixpkgs/commit/dceec6d7e6c6b75f86be20221e138edc0e9e0ce7) | `` turso-cli: 0.96.0 -> 0.96.2 ``                                                     |
| [`9b9bade4`](https://github.com/NixOS/nixpkgs/commit/9b9bade45cbff5cb134bb4107117e89601db4730) | `` urlscan: 1.0.2 -> 1.0.3 ``                                                         |
| [`9bdcea6d`](https://github.com/NixOS/nixpkgs/commit/9bdcea6da7589f80d9903ec0831be2d273e5be2f) | `` vimPlugins.nvim-treesitter: update grammars ``                                     |
| [`602cf2d2`](https://github.com/NixOS/nixpkgs/commit/602cf2d22c6ac85390f1e24a611c50a9a8c7e5dd) | `` vimPlugins: resolve github repository redirects ``                                 |
| [`438b1e92`](https://github.com/NixOS/nixpkgs/commit/438b1e92cd592b99ab12826b8588cfe954244688) | `` vimPlugins: update on 2024-07-18 ``                                                |
| [`4811b4cb`](https://github.com/NixOS/nixpkgs/commit/4811b4cbb1f0ad1923196b9ebb0b8f86808e143b) | `` vmagent: dont update via nixpkgs-update ``                                         |