### PR TITLE
chore(flake/rust-overlay): `0b2b2da1` -> `56baac5e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1721528458,
-        "narHash": "sha256-uruH/EV8Rpa/CRxn8CiMzhoA6tJe8qO5c8NdgP1g0rM=",
+        "lastModified": 1722046723,
+        "narHash": "sha256-G7/gHz8ORRvHd1/RIURrdcswKRPe9K0FsIYR4v5jSWo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "0b2b2da1dad1c675c45d9e23c75674de969de83b",
+        "rev": "56baac5e6b2743d4730e664ea64f6d8a2aad0fbb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                |
| ----------------------------------------------------------------------------------------------------- | ---------------------- |
| [`56baac5e`](https://github.com/oxalica/rust-overlay/commit/56baac5e6b2743d4730e664ea64f6d8a2aad0fbb) | `` manifest: update `` |
| [`9cbf831c`](https://github.com/oxalica/rust-overlay/commit/9cbf831c5b20a53354fc12758abd05966f9f1699) | `` manifest: update `` |
| [`8b81b8ed`](https://github.com/oxalica/rust-overlay/commit/8b81b8ed00b20fd57b24adcb390bd96ea81ecd90) | `` manifest: update `` |
| [`33a7853f`](https://github.com/oxalica/rust-overlay/commit/33a7853f54f1797b029739297c4593bd96077c20) | `` manifest: update `` |
| [`a6afdaab`](https://github.com/oxalica/rust-overlay/commit/a6afdaab4a47d6ecf647a74968e92a51c4a18e5a) | `` manifest: update `` |
| [`4674ff2c`](https://github.com/oxalica/rust-overlay/commit/4674ff2c2e5423a0cebe16e61aa874c359306af4) | `` manifest: update `` |
| [`424a7595`](https://github.com/oxalica/rust-overlay/commit/424a759557ed4c01cf9dbbf79a714150d64a90ad) | `` manifest: update `` |